### PR TITLE
Enforce installing from local directory instead of from PyPi

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -36,7 +36,7 @@ RUN sed --in-place 's/#listen =.*/listen = 0.0.0.0:8000/' /etc/nextcloud-talk-re
 RUN mkdir --parents /tmp/recording
 COPY src /tmp/recording/
 COPY pyproject.toml /tmp/recording/
-RUN python3 -m pip install /tmp/recording/
+RUN python3 -m pip install file:///tmp/recording/
 
 # Cleanup
 RUN apt-get clean && rm --recursive --force /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,7 @@ Those dependencies must be installed, typically using the package manager of the
 Then, the recording server and all its Python dependencies can be installed using Python pip. Note that the recording server is not available in the Python Package Index (PyPI); you need to manually clone the git repository and then install it from there:
 ```
 git clone https://github.com/nextcloud/nextcloud-talk-recording
-python3 -m pip install nextcloud-talk-recording
+python3 -m pip install "file://$(pwd)/nextcloud-talk-recording"
 ```
 
 The recording server does not need to be run as root (and it should not be run as root). It can be started as a regular user with `nextcloud-talk-recording --config {PATH_TO_THE_CONFIGURATION_FILE)` (or, if the helper script is not available, directly with `python3 -m nextcloud.talk.recording --config {PATH_TO_THE_CONFIGURATION_FILE)`. Nevertheless, please note that the user needs to have a home directory.

--- a/start-container.sh
+++ b/start-container.sh
@@ -190,7 +190,7 @@ if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER$")" ]; then
 	docker cp . $CONTAINER:/tmp/recording/
 
 	echo "Installing recording backend inside container"
-	docker exec $CONTAINER python3 -m pip install /tmp/recording/
+	docker exec $CONTAINER python3 -m pip install file:///tmp/recording/
 
 	echo "Copying configuration from server.conf.in to /etc/nextcloud-talk-recording/server.conf"
 	docker exec $CONTAINER mkdir --parent /etc/nextcloud-talk-recording/


### PR DESCRIPTION
When a "plain" name is given to `pip install` [it looks for matching projects on PyPi and local directories and then installs the best one in terms of version number](https://pip.pypa.io/en/stable/cli/pip_install/#finding-packages).

To ensure that the name is seen as a local directory and directly installed from it rather than also checking PyPi the name must provide any hint of being a local directory. Therefore, if the name is given as `nextcloud-talk-recording/` or `./nextcloud-talk-recording` it should be enough. However, to err on the safe side the longer specification of `"file://$(pwd)/nextcloud-talk-recording"` was used instead (the double quotes also ensure that if there are spaces in the parent directories they will be properly processed).

For consistency `file://` was also added to other uses of `pip install`, even if it was not strictly necessary.
