### PR TITLE
Fix packaging with setuptools 69.3 and later

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -68,7 +68,13 @@ build-packages-deb-nextcloud-talk-recording: $(BUILD_DIR)/deb/nextcloud-talk-rec
 $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(DEBIAN_VERSION)_all.deb: | $(BUILD_DIR)/deb
 	$(call build-source-python-package,$(BUILD_DIR),../)
 
-	$(call extract-source-python-package,nextcloud-talk-recording,$(NEXTCLOUD_TALK_RECORDING_VERSION))
+	# Starting with setup tools 69.3 the name of the generated Python source
+	# package is canonicalized based on PEP 625, so it becomes
+	# "nextcloud_talk_recording". The name of the Debian binary package is
+	# not affected, so it is still matches the project name,
+	# "nextcloud-talk-recording".
+
+	$(call extract-source-python-package,nextcloud_talk_recording,$(NEXTCLOUD_TALK_RECORDING_VERSION))
 
 	# Add extra files needed to create Debian packages:
 	# - debian/py3dist-overrides: Python dependencies to Debian dependencies for
@@ -84,14 +90,14 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 	# - stdeb.cfg: additional configuration for stdeb (not needed in the
 	#   regenerated Python package, as stdeb loads it before changing to the
 	#   uncompressed source Python package).
-	cp --recursive nextcloud-talk-recording/. $(BUILD_DIR)/nextcloud-talk-recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/
-	cp ../server.conf.in $(BUILD_DIR)/nextcloud-talk-recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/
+	cp --recursive nextcloud-talk-recording/. $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/
+	cp ../server.conf.in $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/
 
 	# Build a source Debian package (with the systemd addon for dh) and then,
 	# from it, a binary Debian package.
-	cd $(BUILD_DIR)/nextcloud-talk-recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/ && SOURCE_DATE_EPOCH=$$($(call timestamp-from-git,../../../../)) SETUPTOOLS_USE_DISTUTILS=stdlib python3 setup.py --command-packages=stdeb.command sdist_dsc --with-dh-systemd --debian-version $(DEBIAN_VERSION) bdist_deb
+	cd $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/ && SOURCE_DATE_EPOCH=$$($(call timestamp-from-git,../../../../)) SETUPTOOLS_USE_DISTUTILS=stdlib python3 setup.py --command-packages=stdeb.command sdist_dsc --with-dh-systemd --debian-version $(DEBIAN_VERSION) bdist_deb
 
-	$(call copy-binary-deb-package,nextcloud-talk-recording,$(NEXTCLOUD_TALK_RECORDING_VERSION),nextcloud-talk-recording)
+	$(call copy-binary-deb-package,nextcloud_talk_recording,$(NEXTCLOUD_TALK_RECORDING_VERSION),nextcloud-talk-recording)
 
 # Builds the Python dependencies that are not included in at least one of the
 # Ubuntu supported releases:

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -179,7 +179,7 @@ if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER-ubuntu22.04$")" ]
 	# Even with virtualenv there is no proper virtual environment, so the build
 	# dependencies specified in pyproject.toml need to be installed system wide.
 	docker exec $CONTAINER-ubuntu22.04 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-pip python3-virtualenv python3-build python3-stdeb python3-all debhelper dh-python git dh-exec"
-	docker exec $CONTAINER-ubuntu22.04 bash -c "python3 -m pip install 'setuptools >= 61.0, < 69.3'"
+	docker exec $CONTAINER-ubuntu22.04 bash -c "python3 -m pip install 'setuptools >= 69.3'"
 	# Some packages need to be installed so the unit tests can be run in the
 	# packages being built.
 	docker exec $CONTAINER-ubuntu22.04 bash -c "apt-get install --assume-yes pulseaudio python3-async-generator python3-trio python3-wsproto"

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -173,8 +173,13 @@ if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER-ubuntu22.04$")" ]
 	echo "Installing required build dependencies"
 	# "noninteractive" is used to provide default settings instead of asking for
 	# them (for example, for tzdata).
+	# Due to a bug in python3-build in Ubuntu 22.04 python3-virtualenv needs to
+	# be used instead of python3-venv:
+	# https://bugs.launchpad.net/ubuntu/+source/python-build/+bug/1992108
+	# Even with virtualenv there is no proper virtual environment, so the build
+	# dependencies specified in pyproject.toml need to be installed system wide.
 	docker exec $CONTAINER-ubuntu22.04 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-pip python3-virtualenv python3-build python3-stdeb python3-all debhelper dh-python git dh-exec"
-	docker exec $CONTAINER-ubuntu22.04 bash -c "python3 -m pip install 'setuptools >= 61.0'"
+	docker exec $CONTAINER-ubuntu22.04 bash -c "python3 -m pip install 'setuptools >= 61.0, < 69.3'"
 	# Some packages need to be installed so the unit tests can be run in the
 	# packages being built.
 	docker exec $CONTAINER-ubuntu22.04 bash -c "apt-get install --assume-yes pulseaudio python3-async-generator python3-trio python3-wsproto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 dynamic = ["version"]
 
 [build-system]
-requires = ["setuptools >= 61.0, < 69.3"]
+requires = ["setuptools >= 69.3"]
 build-backend = "setuptools.build_meta"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[build-system]
+requires = ["setuptools >= 61.0, < 69.3"]
+build-backend = "setuptools.build_meta"
+
 [project.urls]
 repository = "https://github.com/nextcloud/nextcloud-talk-recording"
 


### PR DESCRIPTION
Before setuptools 69.3 the name of the [generated Python source package](https://github.com/nextcloud/nextcloud-talk-recording/blob/cbf128e34aa34298876f45e722ee830022f01b69/packaging/Makefile#L42) was the same as [the project name](https://github.com/nextcloud/nextcloud-talk-recording/blob/4d0abc758a2daa52c21bef1dc43a07b0500717f3/pyproject.toml#L2). However, that happened to work like that, it was not an explicit behaviour so to speak. Starting with setuptools 69.3 (see pull request 4286 and issue 4300 in https://github.com/pypa/setuptools/issues/, not linking to avoid polluting them with backlinks) support for [PEP 625](https://peps.python.org/pep-0625/) was implemented, so `-` is now replaced with `_` in the name of the source distribution.

When building the packages setuptools is used in two different places: it is first used by `build` to [generate a Python source package](https://github.com/nextcloud/nextcloud-talk-recording/blob/cbf128e34aa34298876f45e722ee830022f01b69/packaging/Makefile#L69), and then it is used by `stdeb` to [generate a Debian binary package](https://github.com/nextcloud/nextcloud-talk-recording/blob/cbf128e34aa34298876f45e722ee830022f01b69/packaging/Makefile#L92). In the second case it is also used to generate a Python source package again, but it is internally done by `stdeb` using Python modules, so it gets the resulting name from function calls and it is not affected by the changes in it. However, in the first case the name change breaks the build, as in the _Makefile_ it was expected that the source package name matched the project name.

Both setuptools are (mostly) independent one from each other; the one used by `build` is installed in a virtual environment, while the one used by `stdeb` is the one installed in the system. The one installed by `build` is based on the `build-system` section of _pyproject.toml_; if no build system is specified then setuptools >= 40.8.0 is used by default (even [in latest version](https://github.com/pypa/build/blob/9eede7168c6b0041ba33660adb08dfa227e00df3/src/build/_builder.py#L35)).

Due to all that, in order to fix the building it would be necessary to either explicitly pin setuptools < 69.3 in _pyproject.toml_, so the current _Makefile_ still works, or pin it to >= 69.3 and adjust the _Makefile_. Strictly speaking this should not be in _pyproject.toml_, as it is not an actual requirement to build the source distribution of the project in general but only when used with the Makefile to build the distribution packages. But for simplicity it will be set like that, at least for now.

But wait, there is more ;-)

If setuptools < 69.3 is set in _pyproject.toml_ but not in _build.sh_ then building works in Debian 11 and Ubuntu 20.04, but not in Ubuntu 22.04. `build` uses `venv` in Debian 11 and Ubuntu 20.04, but in Ubuntu 22.04 [there is a bug in `python3-build` that causes `venv` to fail when creating a virtual environment](https://bugs.launchpad.net/ubuntu/+source/python-build/+bug/1992108). That can be workarounded by using `virtualenv` instead of `venv`; in that case it seems that `virtualenv` still does not create a proper virtual environment but gets the packages from the system (problem specific to Ubuntu 22.04, probably the same underlying bug), so when it tries to install setuptools < 69.3 to build the package it tries to replace setuptools 70.0.0 (because, as it is installed without an upper bound in _build.sh_ the latest available version is installed) in the system with setuptools 69.2. As `build` is run as a regular user it has no permissions to replace the files, so creating the "isolated" environment fails and with that building the Python source package.

Therefore, in the case of Ubuntu 22.04, as there is no actual virtual environment, the build dependencies must be explicitly installed in _build.sh_ to match those stated in _pyproject.toml_.
