### PR TITLE
Run lint-python workflow on ubuntu latest

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   run-python-lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-versions: [ '3.8', '3.11' ]


### PR DESCRIPTION
Follow up to #1 

This will make possible to use both GitHub runners and self-hosted runners rather than only GitHub runners.