### PR TITLE
Add Prometheus stats

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,3 +12,7 @@
 ## API
 
 * [Recording API](recording-api.md)
+
+## Other
+
+* [Prometheus metrics](prometheus-metrics.md)

--- a/docs/prometheus-metrics.md
+++ b/docs/prometheus-metrics.md
@@ -1,0 +1,14 @@
+# Prometheus metrics
+
+The recording server exposes various metrics that can be queried by a [Prometheus](https://prometheus.io/) server from the `/metrics` endpoint.
+
+Only clients connecting from an IP that is included in the `allowed_ips` value of the `[stats]` entry in the configuration file are allowed to query the metrics.
+
+## Available metrics
+
+The following metrics are available:
+
+| Metric                                            | Type      | Since     | Description                                                               | Labels                            |
+| :------------------------------------------------ | :-------- | --------: | :------------------------------------------------------------------------ | :-------------------------------- |
+| `recording_recordings_current`                    | Gauge     | 1.0.0     | The current number of recordings                                          | `backend`                         |
+| `recording_recordings_total`                      | Counter   | 1.0.0     | The total number of recordings                                            | `backend`                         |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
 ]
 dependencies = [
     "flask",
+    "prometheus-client",
     "psutil",
     "pulsectl",
     "pyvirtualdisplay>=2.0",

--- a/server.conf.in
+++ b/server.conf.in
@@ -126,3 +126,9 @@
 # Allowed values: firefox, chrome
 # Defaults to firefox
 # browser = firefox
+
+[stats]
+# Comma-separated list of IP addresses (or CIDR networks) that are allowed to
+# access the stats endpoint.
+# Leave commented to only allow access from "127.0.0.1".
+#allowed_ips =

--- a/src/nextcloud/talk/recording/Server.py
+++ b/src/nextcloud/talk/recording/Server.py
@@ -31,7 +31,9 @@ from ipaddress import ip_address
 from threading import Lock, Thread
 
 from flask import Flask, jsonify, request
+from prometheus_client import make_wsgi_app
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from nextcloud.talk import recording
 from nextcloud.talk.recording import RECORDING_STATUS_AUDIO_AND_VIDEO
@@ -166,6 +168,10 @@ class TrustedProxiesFix:
 
 app = Flask(__name__)
 app.wsgi_app = TrustedProxiesFix(app.wsgi_app, config)
+
+app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
+    '/metrics': make_wsgi_app()
+})
 
 services = {}
 servicesStopping = {}

--- a/tests/ConfigTest.py
+++ b/tests/ConfigTest.py
@@ -368,3 +368,37 @@ internalsecret = the-internal-secret2
 
         signalingUrl = 'https://signaling.server2.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2'
+
+    def testGetStatsAllowedIps(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[stats]
+allowed_ips = 127.0.0.1, 2001:db8::0, not-an-ip, 192.168.0.0/16, 2001:db8::1234:0/112
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getStatsAllowedIps() == [
+            ip_network('127.0.0.1'),
+            ip_network('2001:db8::0'),
+            ip_network('192.168.0.0/16'),
+            ip_network('2001:db8::1234:0/112')
+        ]
+
+    def testGetStatsAllowedIpsWhenCommented(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[stats]
+#allowed_ips =
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getStatsAllowedIps() == [
+            ip_network('127.0.0.1')
+        ]
+
+    def testGetStatsAllowedIpsWhenEmpty(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[stats]
+allowed_ips =
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getStatsAllowedIps() == []


### PR DESCRIPTION
The stats can be queried using the "/metrics" endpoint, but only from IP addresses explicitly allowed in the configuration.

The _prometheus-metrics.md_ file is based (read, shamelessly copied, @fancycode sorry about that, I hope that is fine :-) ) from the signaling server.
