### PR TITLE
Remove unneeded visit to main Nextcloud server page

### DIFF
--- a/src/nextcloud/talk/recording/Participant.py
+++ b/src/nextcloud/talk/recording/Participant.py
@@ -482,8 +482,6 @@ class Participant():
         else:
             raise Exception('Invalid browser: ' + browser)
 
-        self.seleniumHelper.driver.get(nextcloudUrl)
-
     def joinCall(self, token):
         """
         Joins the call in the room with the given token.


### PR DESCRIPTION
This is just an unneeded leftover from the initial experiments with recordings. Moreover, it could prevent recordings from starting, for example if SAML is enabled in the Nextcloud server and the identity provider is not accesible from the recording server, as an exception would be thrown in that case when creating the Participant object.