### PR TITLE
Set a unique name for each Pylint check

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -43,4 +43,5 @@ jobs:
       - name: Lint
         uses: wearerequired/lint-action@548d8a7c4b04d3553d32ed5b6e91eb171e10e7bb # v2.3.0
         with:
+          check_name: ${linter} (${{ matrix.python-versions }})
           pylint: true


### PR DESCRIPTION
The lint action is used several times in the same workflow due to [being run using a matrix of Python versions](https://github.com/nextcloud/nextcloud-talk-recording/blob/9a9a3f867a83c87c85b29959662662c7725dc622/.github/workflows/lint-python.yml#L24). Due to that the check created by [it needs to have a unique name for each run](https://github.com/wearerequired/lint-action/blob/df31ae8635c46366688e0bea44d7aba2e1468813/README.md#general-options), or otherwise once a new run finished the previous check was overwritten.