### PR TITLE
Disable linter check for "too-many-positional-arguments"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ disable = [
     "too-many-arguments",
     "too-many-instance-attributes",
     "too-many-locals",
+    "too-many-positional-arguments",
     "too-many-statements",
     # FIXME: these messages should be fixed rather than disabled
     "bare-except",


### PR DESCRIPTION
While the checks point to code that could be improved, at least for now the check [is disabled like other checks using arbitrary thresholds](https://github.com/nextcloud/nextcloud-talk-recording/commit/926627474073827905a48a5429c363d373700bd2).

The check was not originally disabled with the others because it did not even exist back then (see 9842 in https://github.com/pylint-dev/pylint/pulls, not linking directly to avoid polluting that pull request with a back reference).