### PR TITLE
fix: Fix license information for Selenium packaging files

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,8 +8,8 @@ SPDX-PackageDownloadLocation = "https://github.com/nextcloud/nextcloud-talk-reco
 [[annotations]]
 path = ["packaging/selenium/debian/py3dist-overrides", "packaging/selenium/MANIFEST.in"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 SeleniumHQ and contributors"
-SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileCopyrightText = "2023 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
 path = ["packaging/nextcloud-talk-recording/debian/py3dist-overrides", "packaging/nextcloud-talk-recording/MANIFEST.in"]


### PR DESCRIPTION
The Selenium packaging files are not part of the Selenium project. They are exclusive to the recording server packaging system and were written from scratch by Nextcloud developers, so the same license and copyright as for the rest of the recording server applies.