### PR TITLE
Fix logging pmem as a number

### DIFF
--- a/src/nextcloud/talk/recording/Benchmark.py
+++ b/src/nextcloud/talk/recording/Benchmark.py
@@ -78,7 +78,7 @@ class ResourcesTracker:
             self.cpuPercents.append(cpuPercent)
 
             memoryInfo = process.memory_info()
-            self.logger.info("Memory info: %f", memoryInfo)
+            self.logger.info("Memory info: %s", memoryInfo)
             self.memoryInfos.append(memoryInfo)
 
             memoryPercent = process.memory_percent()


### PR DESCRIPTION
## How to test

- Run the benchmark in verbose mode with something like `nextcloud-talk-recording-benchmark --verbose --length 10 /tmp/test-input.webm /tmp/test-output.webm`

### Result with this pull request

No errors

### Result without this pull request

`TypeError: must be real number, not pmem` (along with stack traces) will be printed for every memory info
