### PR TITLE
Fix building with stdeb 0.11.0

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -140,7 +140,7 @@ if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER-debian11$")" ]; t
 	# "noninteractive" is used to provide default settings instead of asking for
 	# them (for example, for tzdata).
 	docker exec $CONTAINER-debian11 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-pip python3-venv python3-all debhelper dh-python git dh-exec"
-	docker exec $CONTAINER-debian11 bash -c "python3 -m pip install stdeb build 'setuptools >= 61.0'"
+	docker exec $CONTAINER-debian11 bash -c "python3 -m pip install 'stdeb < 0.11.0' build 'setuptools >= 61.0'"
 fi
 if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER-ubuntu20.04$")" ]; then
 	echo "Creating Nextcloud Talk recording packages builder container for Ubuntu 20.04"
@@ -150,7 +150,7 @@ if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER-ubuntu20.04$")" ]
 	# "noninteractive" is used to provide default settings instead of asking for
 	# them (for example, for tzdata).
 	docker exec $CONTAINER-ubuntu20.04 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-pip python3-venv python3-all debhelper dh-python git dh-exec"
-	docker exec $CONTAINER-ubuntu20.04 bash -c "python3 -m pip install stdeb build 'setuptools >= 61.0'"
+	docker exec $CONTAINER-ubuntu20.04 bash -c "python3 -m pip install 'stdeb < 0.11.0' build 'setuptools >= 61.0'"
 fi
 if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER-ubuntu22.04$")" ]; then
 	echo "Creating Nextcloud Talk recording packages builder container for Ubuntu 22.04"


### PR DESCRIPTION
[stdeb 0.11.0 raised the minimum debhelper version to 12](https://github.com/stdeb/stdeb/blob/release-0.11.0/README.rst?plain=1#L67-L71). However, [it still uses `--with systemd`](https://github.com/stdeb/stdeb/blob/release-0.11.0/stdeb/util.py#L1246-L1247), which is only supported in debhelper <= 10, so building the nextcloud-talk-recording package fails.

Besides that, it also changed the build system from python_distutils to pybuild, which causes the build of Selenium to fail.

Due to all that, stdeb is pinned to < 0.11.0.