### PR TITLE
Fix Selenium manager permissions in selenium-4.14.0 package

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -128,6 +128,10 @@ $(BUILD_DIR)/deb/python3-selenium_$(SELENIUM_VERSION)-$(DEBIAN_VERSION)_all.deb:
 	# appended rather than just copied.
 	cat selenium/MANIFEST.in >> $(BUILD_DIR)/selenium-$(SELENIUM_VERSION)/MANIFEST.in
 
+	# The source Python package includes a pre-built Selenium manager, but
+	# without execute permissions, so they need to be explicitly set.
+	chmod a+x $(BUILD_DIR)/selenium-$(SELENIUM_VERSION)/selenium/webdriver/common/linux/selenium-manager
+
 	$(call build-deb-package,selenium,$(SELENIUM_VERSION),$$($(call timestamp-from-source-python-package,../selenium-$(SELENIUM_VERSION).tar.gz)))
 
 	$(call copy-binary-deb-package,selenium,$(SELENIUM_VERSION),python3-selenium)


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/nextcloud-talk-recording/pull/62

The Python package for Selenium 4.14.0 provides a pre-built selenium-manager*, but in the source package it does not have execute permissions (it does on the binary, though). As the file is just copied as is from the source Python package to the .deb package it is necessary to explicitly set the execute permissions.

Note that this implies that an executable for a specific architecture is included in a .deb package for any architecture. While that is indeed incorrect for now it will be kept as is, [as it is not possible to build selenium-manager for Linux on other architectures other than amd64](https://www.selenium.dev/documentation/selenium_manager/#alternative-architectures), and using Selenium manager can be skipped by [explicitly providing a path to the driver in the recording server configuration](https://github.com/nextcloud/nextcloud-talk-recording/blob/d41d2c9b11004a2a209d06017d7a1093670959b8/docs/installation.md#the-selenium-driver-or-the-browser-can-not-be-found).

*The pre-built selenium-manager was removed in Selenium 4.23, so from that version on it is needed to explicitly build it. However that comes with its own problems, as the needed Rust version is not available in Debian 11, Selenium 4.23 is not compatible with Ubuntu 20.04 due to requiring Python 3.9, and it can not be built in Ubuntu 22.04 due to the pinned setuptools version. But... something for later.