### PR TITLE
Fix minimum required version of Selenium

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -87,9 +87,9 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 
 # Builds the Python dependencies that are not included in at least one of the
 # Ubuntu supported releases:
-# - Debian 11 (bullseye): pulsectl, pyvirtualdisplay >= 2.0, selenium >= 4.6.0
-# - Ubuntu 20.04 (focal): pulsectl, pyvirtualdisplay >= 2.0, requests >= 2.25, selenium >= 4.6.0
-# - Ubuntu 22.04 (jammy): pulsectl, selenium >= 4.6.0
+# - Debian 11 (bullseye): pulsectl, pyvirtualdisplay >= 2.0, selenium >= 4.11.0
+# - Ubuntu 20.04 (focal): pulsectl, pyvirtualdisplay >= 2.0, requests >= 2.25, selenium >= 4.11.0
+# - Ubuntu 22.04 (jammy): pulsectl, selenium >= 4.11.0
 #
 # requests is not an explicit dependency, but required by requests-toolbelt.
 # However, requests < 2.25 is not compatible with urllib3 >= 1.26, which is

--- a/packaging/nextcloud-talk-recording/debian/py3dist-overrides
+++ b/packaging/nextcloud-talk-recording/debian/py3dist-overrides
@@ -1,3 +1,3 @@
 pulsectl python3-pulsectl
 pyvirtualdisplay python3-pyvirtualdisplay (>= 2.0)
-selenium python3-selenium (>= 4.6.0)
+selenium python3-selenium (>= 4.11.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pulsectl",
     "pyvirtualdisplay>=2.0",
     "requests-toolbelt",
-    "selenium>=4.6.0",
+    "selenium>=4.11.0",
     "websocket-client",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Follow up to #33

Since 17c0ff27ae `None` is set by default as the driver path if not explicitly configured. However, in Selenium <= 4.10 [passing `None` was not supported](https://github.com/SeleniumHQ/selenium/commit/6176d7ec65416db8525194119b3f62bfaaba01b4#diff-06cebae290653d9a47afbbf9de789bbb1123db4c2ab5456984ff19bff0e40f50L37) and caused a `TypeError` to be thrown.