### PR TITLE
Fix required version of Selenium 4.14.0 dependencies

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -139,7 +139,7 @@ $(BUILD_DIR)/deb/python3-selenium_$(SELENIUM_VERSION)-$(DEBIAN_VERSION)_all.deb:
 # Builds the Python dependencies that are not included in at least one of the
 # Ubuntu supported releases:
 # - Debian 11 (bullseye): python3-certifi >= 2021.10.8, python3-trio ~= 0.17, python3-trio-websocket ~= 0.9
-# - Ubuntu 20.04 (focal): python3-certifi >= 2021.10.8, python3-trio ~= 0.17, python3-trio-websocket ~= 0.9, python3-urllib3 ~= 1.26
+# - Ubuntu 20.04 (focal): python3-certifi >= 2021.10.8, python3-trio ~= 0.17, python3-trio-websocket ~= 0.9, python3-urllib3 >= 1.26, < 3
 # - Ubuntu 22.04 (jammy): python3-certifi >= 2021.10.8, python3-trio-websocket ~= 0.9
 build-packages-deb-selenium-dependencies: build-packages-deb-selenium-dependencies-$(OS_VERSION)
 


### PR DESCRIPTION
Follow up to #62

See https://github.com/SeleniumHQ/selenium/blob/selenium-4.14.0/py/setup.py#L73-L78