### PR TITLE
ci: Add cooldown for Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     day: saturday
     time: "03:00"
     timezone: Europe/Berlin
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
The cooldown period gives maintainers a chance to revoke compromised releases before they roll out.