### PR TITLE
Update Dockerfile

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,9 +1,6 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
-# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --assume-yes update
 RUN apt-get --assume-yes upgrade
@@ -12,11 +9,11 @@ RUN apt-get --assume-yes upgrade
 RUN apt-get --assume-yes install software-properties-common
 
 # nextcloud-talk-recording dependencies
-RUN apt-get --assume-yes install ffmpeg pulseaudio python3-pip xvfb
-RUN pip3 install --upgrade requests
+RUN apt-get --assume-yes install ffmpeg pulseaudio python3-pip python3-venv xvfb
 
 # firefox
-RUN apt-get --assume-yes install firefox firefox-geckodriver
+# RUN apt-get --assume-yes install firefox firefox-geckodriver (replaced by the below)
+RUN apt-get --assume-yes install firefox
 
 # chromium
 # The phd/chromium repository for Ubuntu is used because since Ubuntu 20.04
@@ -28,6 +25,7 @@ RUN apt-get update
 RUN apt-get --assume-yes install chromium
 
 COPY ./docker-compose/wrap_chromium_binary /opt/bin/wrap_chromium_binary
+RUN chmod u+x /opt/bin/wrap_chromium_binary
 RUN /opt/bin/wrap_chromium_binary
 
 # nextcloud-talk-recording config
@@ -35,17 +33,30 @@ RUN useradd --create-home recording
 COPY server.conf.in /etc/nextcloud-talk-recording/server.conf
 RUN sed --in-place 's/#listen =.*/listen = 0.0.0.0:8000/' /etc/nextcloud-talk-recording/server.conf
 
-# Deploy recording server
+# Cleanup
+RUN apt-get clean && rm --recursive --force /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy recording server sources
 RUN mkdir --parents /tmp/recording
 COPY src /tmp/recording/
 COPY pyproject.toml /tmp/recording/
-RUN python3 -m pip install file:///tmp/recording/
+RUN chown -R recording:recording /tmp/recording
 
-# Cleanup
-RUN apt-get clean && rm --recursive --force /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN rm --recursive --force /tmp/recording
-
-# Switch user and start the recording server
+# Switch user
 WORKDIR "/home/recording/"
 USER "recording"
+
+# create python virtual env
+ENV VIRTUAL_ENV=/home/recording/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# install python requirements and the recording server
+RUN python3 -m pip install --upgrade requests
+RUN python3 -m pip install file:///tmp/recording/
+
+# cleanup
+RUN rm --recursive --force /tmp/recording
+
+# start the recording server
 CMD ["python3", "-m", "nextcloud.talk.recording", "--config", "/etc/nextcloud-talk-recording/server.conf"]


### PR DESCRIPTION
modified docker file

had issues with building the docker image because of installing python dependencies and project because in a lack of virtual environment

reordered the docker file in order to:
1. install all requirements at the OS level (firefox, chromium...) that requires root privilege
2. create the user recording
3. switch user and install the recording user backend inside the user context AND a user python virtual environment

Side remark: it seems that firefox gecko driver is not needed anymore, so removed from the file

NB: also changed base image from ubuntu 20.04 to ubuntu 24.04

I am unsure if going through python virtual env is the right or state of the art approach, but it is the one that worked best for me.