### PR TITLE
Treat "https://" and "wss://" as equivalent in signaling URL

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -222,7 +222,7 @@ Note that in some cases the error `Unable to obtain driver for firefox/chrome` m
 
 This error will be logged when a recording was started, but the recording server is unable to determine the secret for the signaling server. In this case:
 - Verify that the `url` parameter of the signaling configuration is correct
-- Check that you're using the same URL scheme (`https://` vs. `wss://`) for the signaling server in your nextcloud instance and the recording server
+- Check that you are using the same URL scheme (`https://` vs. `wss://`) for the signaling server in your Nextcloud instance and the recording server
 
 ### The recording is stuck in _Starting_ but never starts nor fails
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -222,7 +222,7 @@ Note that in some cases the error `Unable to obtain driver for firefox/chrome` m
 
 This error will be logged when a recording was started, but the recording server is unable to determine the secret for the signaling server. In this case:
 - Verify that the `url` parameter of the signaling configuration is correct
-- Check that you are using the same URL scheme (`https://` vs. `wss://`) for the signaling server in your Nextcloud instance and the recording server
+- In version 0.2.1 and older, check that you are using the same URL scheme (`https://` vs. `wss://`) for the signaling server in your Nextcloud instance and the recording server
 
 ### The recording is stuck in _Starting_ but never starts nor fails
 

--- a/src/nextcloud/talk/recording/Config.py
+++ b/src/nextcloud/talk/recording/Config.py
@@ -128,6 +128,11 @@ class Config:
                 continue
 
             signalingUrl = self._configParser[signalingId]['url'].rstrip('/')
+            if signalingUrl.startswith('https://'):
+                signalingUrl = 'wss://' + signalingUrl[len('https://'):]
+            elif signalingUrl.startswith('http://'):
+                signalingUrl = 'ws://' + signalingUrl[len('http://'):]
+
             self._signalingIdsBySignalingUrl[signalingUrl] = signalingId
 
     def _loadStatsAllowedIps(self):
@@ -250,9 +255,18 @@ class Config:
         Returns the shared secret for authenticating as an internal client of
         signaling servers.
 
+        URLs starting with https:// and wss:// are treated as equivalent. Same
+        with URLs starting with http:// and ws://.
+
         Defaults to None.
         """
         signalingUrl = signalingUrl.rstrip('/')
+        if signalingUrl not in self._signalingIdsBySignalingUrl:
+            if signalingUrl.startswith('https://'):
+                signalingUrl = 'wss://' + signalingUrl[len('https://'):]
+            elif signalingUrl.startswith('http://'):
+                signalingUrl = 'ws://' + signalingUrl[len('http://'):]
+
         if signalingUrl in self._signalingIdsBySignalingUrl:
             signalingId = self._signalingIdsBySignalingUrl[signalingUrl]
 

--- a/tests/ConfigTest.py
+++ b/tests/ConfigTest.py
@@ -296,6 +296,9 @@ directory = /srv/recording
         signalingUrl = 'https://signaling.unknown.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
 
+        signalingUrl = 'wss://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
     def testGetSignalingSecretWhenSet(self, configLoadedFromString):
         configLoadedFromString.configString = """
 [signaling]
@@ -311,6 +314,12 @@ url = https://signaling.server.com
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret-common'
 
         signalingUrl = 'https://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret-common'
+
+        signalingUrl = 'wss://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret-common'
+
+        signalingUrl = 'wss://signaling.server.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret-common'
 
     def testGetSignalingSecretWhenSetBySignaling(self, configLoadedFromString):
@@ -330,7 +339,16 @@ internalsecret = the-internal-secret
         signalingUrl = 'https://signaling.server.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
 
+        signalingUrl = 'wss://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'wss://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
+
         signalingUrl = 'http://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'ws://signaling.server.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
 
     def testGetSignalingSecretWhenSetBySignalingAsPlainHttp(self, configLoadedFromString):
@@ -350,14 +368,81 @@ internalsecret = the-internal-secret
         signalingUrl = 'http://signaling.server.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
 
+        signalingUrl = 'ws://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'ws://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
+
         signalingUrl = 'https://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'wss://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+    def testGetSignalingSecretWhenSetBySignalingAsWebSocket(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[signaling]
+signalings = signaling1
+
+[signaling1]
+url = wss://signaling.server.com
+internalsecret = the-internal-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        signalingUrl = 'https://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'https://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
+
+        signalingUrl = 'wss://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'wss://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
+
+        signalingUrl = 'http://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'ws://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+    def testGetSignalingSecretWhenSetBySignalingAsPlainWebSocket(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[signaling]
+signalings = signaling1
+
+[signaling1]
+url = ws://signaling.server.com
+internalsecret = the-internal-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        signalingUrl = 'http://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'http://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
+
+        signalingUrl = 'ws://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'ws://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
+
+        signalingUrl = 'https://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'wss://signaling.server.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
 
     def testGetSignalingSecretWhenSeveralSignalings(self, configLoadedFromString):
         configLoadedFromString.configString = """
 [signaling]
 internalsecret = the-internal-secret-common
-signalings = signaling1, signaling2, signaling2-plain
+signalings = signaling1, signaling2, signaling2-plain, signaling3, signaling4, signaling4-plain
 
 [signaling1]
 url = https://signaling.server1.com
@@ -370,6 +455,18 @@ internalsecret = the-internal-secret2
 [signaling2-plain]
 url = http://signaling.server2.com
 internalsecret = the-internal-secret2-plain
+
+[signaling3]
+url = wss://signaling.server3.com
+internalsecret = the-internal-secret3
+
+[signaling4]
+url = wss://signaling.server4.com
+internalsecret = the-internal-secret4
+
+[signaling4-plain]
+url = ws://signaling.server4.com
+internalsecret = the-internal-secret4-plain
 """
         configLoadedFromString.load('fake-file-name')
 
@@ -384,6 +481,74 @@ internalsecret = the-internal-secret2-plain
 
         signalingUrl = 'http://signaling.server2.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2-plain'
+
+        signalingUrl = 'https://signaling.server3.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret3'
+
+        signalingUrl = 'https://signaling.server4.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret4'
+
+        signalingUrl = 'http://signaling.server4.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret4-plain'
+
+        signalingUrl = 'wss://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret-common'
+
+        signalingUrl = 'wss://signaling.server1.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret1'
+
+        signalingUrl = 'wss://signaling.server2.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2'
+
+        signalingUrl = 'ws://signaling.server2.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2-plain'
+
+        signalingUrl = 'wss://signaling.server3.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret3'
+
+        signalingUrl = 'wss://signaling.server4.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret4'
+
+        signalingUrl = 'ws://signaling.server4.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret4-plain'
+
+    def testGetSignalingSecretWhenSetBySignalingBothAsHttpsAndWebSocket(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[signaling]
+signalings = signaling1, signaling1-wss, signaling2-wss, signaling2
+
+[signaling1]
+url = https://signaling.server1.com
+internalsecret = the-internal-secret1
+
+[signaling1-wss]
+url = wss://signaling.server1.com
+internalsecret = the-internal-secret1-wss
+
+[signaling2-wss]
+url = wss://signaling.server2.com
+internalsecret = the-internal-secret2-wss
+
+[signaling2]
+url = https://signaling.server2.com
+internalsecret = the-internal-secret2
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        # When set with both HTTPS and WSS the signaling server is treated as a
+        # duplicate and the last secret set is used.
+
+        signalingUrl = 'https://signaling.server1.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret1-wss'
+
+        signalingUrl = 'https://signaling.server2.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2'
+
+        signalingUrl = 'wss://signaling.server1.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret1-wss'
+
+        signalingUrl = 'wss://signaling.server2.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2'
 
     def testGetStatsAllowedIps(self, configLoadedFromString):
         configLoadedFromString.configString = """

--- a/tests/ConfigTest.py
+++ b/tests/ConfigTest.py
@@ -330,11 +330,34 @@ internalsecret = the-internal-secret
         signalingUrl = 'https://signaling.server.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
 
+        signalingUrl = 'http://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+    def testGetSignalingSecretWhenSetBySignalingAsPlainHttp(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[signaling]
+signalings = signaling1
+
+[signaling1]
+url = http://signaling.server.com
+internalsecret = the-internal-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        signalingUrl = 'http://signaling.unknown.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
+        signalingUrl = 'http://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret'
+
+        signalingUrl = 'https://signaling.server.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) is None
+
     def testGetSignalingSecretWhenSeveralSignalings(self, configLoadedFromString):
         configLoadedFromString.configString = """
 [signaling]
 internalsecret = the-internal-secret-common
-signalings = signaling1, signaling2
+signalings = signaling1, signaling2, signaling2-plain
 
 [signaling1]
 url = https://signaling.server1.com
@@ -343,6 +366,10 @@ internalsecret = the-internal-secret1
 [signaling2]
 url = https://signaling.server2.com
 internalsecret = the-internal-secret2
+
+[signaling2-plain]
+url = http://signaling.server2.com
+internalsecret = the-internal-secret2-plain
 """
         configLoadedFromString.load('fake-file-name')
 
@@ -354,6 +381,9 @@ internalsecret = the-internal-secret2
 
         signalingUrl = 'https://signaling.server2.com'
         assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2'
+
+        signalingUrl = 'http://signaling.server2.com'
+        assert configLoadedFromString.getSignalingSecret(signalingUrl) == 'the-internal-secret2-plain'
 
     def testGetStatsAllowedIps(self, configLoadedFromString):
         configLoadedFromString.configString = """


### PR DESCRIPTION
Talk accepts both `https://` and `wss://` in the signaling URL and treats them as equivalent, internally using the right protocol depending on the context ([`https://` for API requests](https://github.com/nextcloud/spreed/blob/f0547a510e5300da66968eec1f63df0ffd5b3293/lib/Signaling/BackendNotifier.php#L111-L112) and [`wss://` for signaling connections in the frontend](https://github.com/nextcloud/spreed/blob/c5bebdafbf44a24bd42503879f786b6bbf8a255a/src/utils/signaling.js#L626-L627)). Moreover, [Talk settings seem to imply in its hint that `wss://` should be used](https://github.com/nextcloud/spreed/blob/c095202c750c46662dc7e19053b80497360c6e45/src/components/AdminSettings/SignalingServer.vue#L13), while [the recording server configuration seems to imply in the example configuration that `https://` should be used](https://github.com/nextcloud/nextcloud-talk-recording/blob/544f9d3ddb16f7b3f73d31537c6a5cffcf575b25/server.conf.in#L89). Therefore to reduce configuration issues now the signaling URL got from Talk settings matches for both `https://` and `wss://` when compared against the configured signaling URL.

For completeness and consistency with Talk `http://` and `ws://` are also treated as equivalent, although in practice no signaling server should be configured with `http://` or `ws://`.
