### PR TITLE
fix: Pass environment variables to Makefile

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -219,5 +219,5 @@ USER=$(ls --long --numeric-uid-gid --directory . | sed 's/ \+/ /g' | cut --delim
 
 for TARGET in $TARGETS; do
 	echo "Building recording backend packages for ${TARGET_NAMES[$TARGET]}"
-	docker exec --tty --interactive --user $USER --workdir /nextcloud-talk-recording/packaging $CONTAINER-$TARGET make
+	docker exec --tty --interactive --user $USER --workdir /nextcloud-talk-recording/packaging --env OS_VERSION --env RELEASE --env DEBIAN_VERSION --env BUILD_DIR $CONTAINER-$TARGET make
 done


### PR DESCRIPTION
The Makefile supports customizing the release identifier and the output directory of the built packages through [several optional environment variables](https://github.com/nextcloud/nextcloud-talk-recording/blob/e6a15e3491c45ff66fc9ed5aa8f7cf9538151c2d/packaging/Makefile#L6-L10). The _build.sh_ script now honours those environment variables when calling `make`.

Note that the OS_VERSION should match the distribution where `make` is being run and it should be overridden only if the OS detection is not properly working (so it should not be needed when calling _build.sh_), but it is nevertheless passed for consistency with the other environment variables.
