### PR TITLE
fix: Use home directory under "/var/lib"

### DIFF
--- a/packaging/nextcloud-talk-recording/debian/nextcloud-talk-recording.postinst
+++ b/packaging/nextcloud-talk-recording/debian/nextcloud-talk-recording.postinst
@@ -9,6 +9,10 @@ set -e
 # geckodriver and PulseAudio related files.
 # The user will not be automatically removed if the package is uninstalled or
 # purged to avoid leaving behind files owned by the user/group.
-adduser --system nextcloud-talk-recording
+adduser --system --home /var/lib/nextcloud-talk-recording nextcloud-talk-recording
+
+# "adduser" succeeds if the user already exists even if the home directory does
+# not match, so ensure that the home directory is the expected one.
+usermod --home /var/lib/nextcloud-talk-recording --move-home nextcloud-talk-recording
 
 #DEBHELPER#


### PR DESCRIPTION
`adduser --system` in Debian 11, Ubuntu 20.04 and Ubuntu 22.04 automatically creates and sets a home directory for the user. However, it is created under _/home_, which should be used only for regular users. Moreover, [in adduser 3.122 and later](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=679746#131) (used in Ubuntu 24.04, Debian 12 and later) the home directory is no longer automatically created and needs to be explicitly set with `--home XXX`. Due to all that now [a home directory under _/var/lib_](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#varlibVariableStateInformation) is explicitly set.

The home directory set in `adduser` takes effect only for new users, so if the package is updated from a previous version the existing home directory would be kept. For consistency, the home directory of existing users is also updated to the one under _/var/lib_ using `usermod` (which will do nothing if the home directory is already the expected one).

Note that updating and moving the home directory should work fine even if the package is updated while there is an active recording (and, therefore, active processes for the _nextcloud-talk-recording_ user). Moving the directory in the same filesystem does not change the inode, so open file handles will continue working in the new location, and moving the directory to another filesystem will copy the contents to new inodes, so open file handles will "work" although changes will not be reflected on the new files (see https://www.baeldung.com/linux/open-file-handle-after-move-delete). In any case, the installation scripts restart the recording server (so the running recording is aborted); this is done after the home directory was changed, so it will use the new ones after the restart.

However, if [the temporary directory to store the recordings](https://github.com/nextcloud/nextcloud-talk-recording/blob/98c49982de35dfa85a442bcd16f304dcb22bb427/server.conf.in#L53-L56) was manually changed in the configuration [to use _/home/nextcloud-talk-recording_](https://github.com/nextcloud/nextcloud-talk-recording/blob/23e9b9729340145cf007f26a595c74d12b23a95e/docs/installation.md?plain=1#L112) then new recordings will fail until the configuration is changed to another directory. This will fail once the recording is started (with `PermissionError: [Errno 13] Permission denied: '/home/nextcloud-talk-recording'`, as although [the recording server will try to create the parent directories](https://github.com/nextcloud/nextcloud-talk-recording/blob/ef64a3da7b78196b455d87bfa2b34ec8cc5986cd/src/nextcloud/talk/recording/Service.py#L175) the user `nextcloud-talk-recording` will not have permissions to do so on _/home_), and not when the recording server is started. Nevertheless, the error is straightforward to fix, and automatically updating the recording server configuration to change a manually configured value could be "rude", so the configuration is not touched even if it points to the old home directory.

Besides that, `usermod --home XXX --move-home` does not create the target directory on its own, it moves an existing directory, so if the source directory does not exist the home directory for the system user will be updated, but the target directory will not be created. This should never happen under normal circumstances, though (and if it does `usermod` should print an error during the package installation). Similarly the owner and permissions of the target directory will be those from the source directory, although they are expected to be the right ones already (as the previous directory would have been created with `adduser`).

