### PR TITLE
Add support for building packages for Debian 12, Debian 13 and Ubuntu 24.04

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -12,6 +12,7 @@ The main branch of the [Nextcloud Talk Recording Server repository](https://gith
 
 Distribution packages are supported for the following GNU/Linux distributions:
 - Debian 11
+- Debian 12
 - Ubuntu 20.04
 - Ubuntu 22.04
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -16,6 +16,7 @@ Distribution packages are supported for the following GNU/Linux distributions:
 - Debian 13
 - Ubuntu 20.04
 - Ubuntu 22.04
+- Ubuntu 24.04
 
 They can be built on those distributions by calling `make` in the _recording/packaging_ directory of the git sources. Nevertheless, the Makefile assumes that the build dependencies have been already installed in the system. Therefore it is recommended to run `build.sh` in the _recording/packaging_ directory, which will create Docker containers with the required dependencies and then run `make` inside them. Alternatively the dependencies can be checked under `Installing required build dependencies` in `build.sh` and manually installed in the system. Using `build.sh` the packages can be built for those target distributions on other distributions too.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -13,6 +13,7 @@ The main branch of the [Nextcloud Talk Recording Server repository](https://gith
 Distribution packages are supported for the following GNU/Linux distributions:
 - Debian 11
 - Debian 12
+- Debian 13
 - Ubuntu 20.04
 - Ubuntu 22.04
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ Before packages can be installed using the package managers of the distributions
 
 In Debian 11 there is no _geckodriver_ package, which is required to control Firefox from the recording server. Therefore the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages. Although `add-apt-repository` is available in Debian 11 the PPA does not provide packages for _bullseye_, so the PPA needs to be manually added to use the packages for _focal_ (Ubuntu 20.04):
 ```
-apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 0AB215679C571D1C8325275B9BDB3D89CE49EC21
+apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 738BEB9321D1AAEC13EA9391AEBDF4819BE21867
 echo 'deb https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu focal main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,17 +32,18 @@ In Debian 11 and later there is no _geckodriver_ package, which is required to c
 
 First the signing key for the PPA from Mozilla needs to be added:
 ```
-apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 738BEB9321D1AAEC13EA9391AEBDF4819BE21867
+install --directory --mode 0755 /etc/apt/keyrings
+wget --quiet --output-document=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x738BEB9321D1AAEC13EA9391AEBDF4819BE21867'
 ```
 
 And then the repository itself:
 - In Debian 11, use packages for _focal_ (Ubuntu 20.04):
 ```
-echo 'deb https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu focal main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
+echo 'deb [signed-by=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc] https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu focal main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
 ```
 - In Debian 12, use packages for _jammy_ (Ubuntu 22.04):
 ```
-echo 'deb https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu jammy main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
+echo 'deb [signed-by=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc] https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu jammy main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
 ```
 
 Besides that the Firefox ESR package from the PPA needs to be configured to take precedence over the one in the Debian repositories:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,6 +50,11 @@ echo 'deb [signed-by=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc] https://ppa.l
 echo 'deb [signed-by=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc] https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu noble main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
 ```
 
+After adding the repository the package index needs to be updated with the packages from the repository:
+```
+apt-get update
+```
+
 Besides that the Firefox ESR package from the PPA needs to be configured to take precedence over the one in the Debian repositories:
 ```
 echo '

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,15 +55,6 @@ After adding the repository the package index needs to be updated with the packa
 apt-get update
 ```
 
-Besides that the Firefox ESR package from the PPA needs to be configured to take precedence over the one in the Debian repositories:
-```
-echo '
-Package: *
-Pin: release o=LP-PPA-mozillateam
-Pin-Priority: 1001
-' > /etc/apt/preferences.d/mozilla-firefox
-```
-
 #### Ubuntu 22.04 and later
 
 In Ubuntu 22.04 and later the normal Firefox package was replaced by a Snap. Unfortunately the Snap package can not be used with the default packages (see [Browsers and Snap packages](#browsers-and-snap-packages) for more details), so the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages (`add-apt-repository` is included in the package `software-properties-common`):

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,7 +66,7 @@ Pin-Priority: 1001
 
 #### Ubuntu 22.04 and later
 
-In Ubuntu 22.04 and later the normal Firefox package was replaced by a Snap. Unfortunately the Snap package can not be used with the default packages, so the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages (`add-apt-repository` is included in the package `software-properties-common`):
+In Ubuntu 22.04 and later the normal Firefox package was replaced by a Snap. Unfortunately the Snap package can not be used with the default packages (see [Browsers and Snap packages](#browsers-and-snap-packages) for more details), so the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages (`add-apt-repository` is included in the package `software-properties-common`):
 ```
 add-apt-repository ppa:mozillateam/ppa
 ```
@@ -119,6 +119,35 @@ python3 -m pip install "file://$(pwd)/nextcloud-talk-recording"
 The recording server does not need to be run as root (and it should not be run as root). It can be started as a regular user with `nextcloud-talk-recording --config {PATH_TO_THE_CONFIGURATION_FILE)` (or, if the helper script is not available, directly with `python3 -m nextcloud.talk.recording --config {PATH_TO_THE_CONFIGURATION_FILE)`. Nevertheless, please note that the user needs to have a home directory.
 
 You might want to configure a systemd service (or any equivalent service) to automatically start the recording server when the machine boots. The sources for the _.deb_ packages include a service file in _recording/packaging/nextcloud-talk-recording/debian/nextcloud-talk-recording.service_ that could be used as inspiration.
+
+## Browsers and Snap packages
+
+Browsers installed through Snap packages are not officially supported.
+
+In Ubuntu 24.04 the Snap package for Chromium will be installed when the package for the recording server is installed, as it is a recommended dependency of the Selenium package provided by the distribution. However, it can be just removed afterwards, as recommended dependencies are "soft" dependencies and can be removed without removing the package that installed them. Another possibility would be to prevent the package from being installed in first place by passing `--no-install-recommends` to `apt-get/apt install`, although that would ignore all the recommended dependencies, not only Chromium. Alternatively the package could be just left installed, as although it will not be usable it should not interfere either with the recording server.
+
+### Using Snap packaged browsers
+
+As already mentioned browsers installed through Snap packages are not officially supported. But if, for some unavoidable reason, a Snap browser must be used with the recording server some system changes are needed.
+
+In order to run a command provided by a Snap package the session is expected to have been initialized through PAM, as it requires the setup done by certain modules (like [_pam_systemd_](https://www.freedesktop.org/software/systemd/man/latest/pam_systemd.html)). This is not the case when running a command as a different user with (just) the `User=` option of systemd services, or even with `su --login`.
+
+If a systemd service is used to manage the recording server, like in the pre-built and manually built packages, [a PAM session can be open for its process](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PAMName=) by calling `systemctl edit nextcloud-talk-recording` and adding:
+```
+[Service]
+PAMName=nextcloud-talk-recording
+```
+
+Note, however, that the recording server logs will be no longer shown with `journalctl --unit nextcloud-talk-recording`, and you would need something like `journalctl --unit session-cXXX.scope` instead. You can find the exact unit name by running `journalctl --output with-unit` and looking for a recording server log.
+
+On the other hand, if the recording server is directly run, rather than `su --login nextcloud-talk-recording --shell /bin/bash --command "nextcloud-talk-recording --config /etc/nextcloud-talk-recording/server.conf"` it should be run instead with something like `machinectl shell nextcloud-talk-recording@.host /bin/bash -c "nextcloud-talk-recording --config /etc/nextcloud-talk-recording/server.conf"`.
+
+Besides that, Snaps are meant to be run by normal users, so by default the home directory of the user is expected to be under _/home_. The pre-built and manually built packages run the recording server as a system user with a home directory in _/var/lib/nextcloud-talk-recording_, so [home directories under _/var/lib_ need to be explicitly allowed](https://snapcraft.io/docs/explanation/how-snaps-work/home-outside-home) with:
+```
+snap set system homedirs=/var/lib
+```
+
+Note that, depending on your system configuration, there could be additional restrictions in AppArmor that prevent using home directories for Snaps in _/var/lib_. For example, if it is set as a read-only filesystem somewhere in _/etc/apparmor.d_.
 
 ## Operating system updates when using pre-built packages or packages built with the helper scripts
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,12 +26,23 @@ Finally disk size will also depend on the number of simultaneous recordings, as 
 
 Before packages can be installed using the package managers of the distributions, some distributions have additional requirements that need to be fulfilled first.
 
-#### Debian 11
+#### Debian
 
-In Debian 11 there is no _geckodriver_ package, which is required to control Firefox from the recording server. Therefore the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages. Although `add-apt-repository` is available in Debian 11 the PPA does not provide packages for _bullseye_, so the PPA needs to be manually added to use the packages for _focal_ (Ubuntu 20.04):
+In Debian 11 and later there is no _geckodriver_ package, which is required to control Firefox from the recording server. Therefore the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages. Although `add-apt-repository` is available in Debian 11 and later the PPA does not provide packages for Debian, so the PPA needs to be manually added to use the equivalent packages for Ubuntu.
+
+First the signing key for the PPA from Mozilla needs to be added:
 ```
 apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 738BEB9321D1AAEC13EA9391AEBDF4819BE21867
+```
+
+And then the repository itself:
+- In Debian 11, use packages for _focal_ (Ubuntu 20.04):
+```
 echo 'deb https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu focal main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
+```
+- In Debian 12, use packages for _jammy_ (Ubuntu 22.04):
+```
+echo 'deb https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu jammy main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
 ```
 
 Besides that the Firefox ESR package from the PPA needs to be configured to take precedence over the one in the Debian repositories:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,7 +61,7 @@ echo '
 Package: *
 Pin: release o=LP-PPA-mozillateam
 Pin-Priority: 1001
-' | sudo tee /etc/apt/preferences.d/mozilla-firefox
+' > /etc/apt/preferences.d/mozilla-firefox
 ```
 
 #### Ubuntu 22.04 and later
@@ -77,7 +77,7 @@ echo '
 Package: *
 Pin: release o=LP-PPA-mozillateam
 Pin-Priority: 1001
-' | sudo tee /etc/apt/preferences.d/mozilla-firefox
+' > /etc/apt/preferences.d/mozilla-firefox
 ```
 
 ### Built packages installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,6 +45,10 @@ echo 'deb [signed-by=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc] https://ppa.l
 ```
 echo 'deb [signed-by=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc] https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu jammy main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
 ```
+- In Debian 13, use packages for _noble_ (Ubuntu 24.04):
+```
+echo 'deb [signed-by=/etc/apt/keyrings/mozillateam-ubuntu-ppa.asc] https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu noble main' > /etc/apt/sources.list.d/mozillateam-ubuntu-ppa.list
+```
 
 Besides that the Firefox ESR package from the PPA needs to be configured to take precedence over the one in the Debian repositories:
 ```
@@ -122,6 +126,8 @@ When the recording server is started through its systemd service the configurati
 The configuration file must be edited to set the Nextcloud servers that are allowed to use the recording server, as well as the credentials for the recording server to use the signaling servers of those Nextcloud servers. Please refer to the sections below for the details.
 
 The temporary directory where the videos are stored while being recorded (and if they fail to be uploaded to the Nextcloud server) is `/tmp/`. That directory is typically a temporary file system stored in RAM, so depending on the available RAM and the number of simultaneous recordings it could affect the system or cause some recordings to suddenly fail due to running out of space. This can be customized in `backend->directory` to use a more suitable directory (for example, a directory under the home directory of the user running the recording server).
+
+In Debian 13, if the Selenium package provided by the distribution is used (which it is by default in the pre-built packages and in the packages built with the _build.sh_ script), the Selenium Manager will not be available, so the path to the Selenium driver must be set in `recording->driverPath`. The path to the Selenium driver provided by the default Firefox package is `/usr/bin/geckodriver`.
 
 By default the recording server listens for HTTP requests on `127.0.0.1:8000`. [As described below](#tls-termination-proxy) it is recommended to set up a TLS termination proxy in front of the recording server, and this TLS termination proxy is the one expected to listen on public interfaces. If needed, the IP and port to listen on for HTTP requests can be customized in `http->listen`.
 
@@ -228,7 +234,7 @@ If the recording worked as expected note that there could still be a subtle issu
 
 ### The Selenium driver or the browser can not be found
 
-If the Selenium Manager is not available (for example, when running Linux on arm64/aarch64) when a recording is started Selenium will not be able to find the driver and the recording will fail. When the Selenium Manager is not available the path to the Selenium driver must be explicitly set in the recording server configuration in `recording->driverPath`. In that case the path to the browser may also need to be set in `recording->browserPath` if the Selenium driver is not able to find it.
+If the Selenium Manager is not available (for example, when running Linux on arm64/aarch64, but also on amd64 if not included in the Selenium package) when a recording is started Selenium will not be able to find the driver and the recording will fail. When the Selenium Manager is not available the path to the Selenium driver must be explicitly set in the recording server configuration in `recording->driverPath`. In that case the path to the browser may also need to be set in `recording->browserPath` if the Selenium driver is not able to find it.
 
 Independently of that, even if the Selenium Manager is available, the recording could also fail if `recording->driverPath` or `recording->browserPath` are set to an invalid value. However, in some Selenium versions setting the paths does not fully override the automated handling of Selenium Manager, so if the paths are set to an invalid value the recording could also work due to Selenium Manager still falling back to downloading the driver or the browser.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,6 +115,16 @@ The recording server does not need to be run as root (and it should not be run a
 
 You might want to configure a systemd service (or any equivalent service) to automatically start the recording server when the machine boots. The sources for the _.deb_ packages include a service file in _recording/packaging/nextcloud-talk-recording/debian/nextcloud-talk-recording.service_ that could be used as inspiration.
 
+## Operating system updates when using pre-built packages or packages built with the helper scripts
+
+In Debian 11, Debian 12, Ubuntu 20.04 and Ubuntu 22.04 some of the Python dependencies are not provided by the distribution packages, so the pre-built packages and the packages built with the helper scripts include custom packages for those dependencies.
+
+In Debian 13, Ubuntu 24.04, and later versions the distributions provide packages for all the Python dependencies, so there is no need for custom packages. However, the version of some of the packages provided by the distribution are older than the version of the custom packages, so if the operating system is updated from a previous version where those custom packages were installed the packages from the distribution will not be installed.
+
+It would be highly recommended to use the packages provided by the distribution, and using an older version of those packages is not a problem, so when performing an operating system update to Debian 13 or Ubuntu 24.04 the custom packages should be removed.
+
+This could be done by removing `nextcloud-talk-recording` before the operating system update. After the package is removed the no longer needed dependencies, which in this case should be the custom packages, would be orphaned, so they can be removed with `apt-get autoremove`. Note that all this must be done before the operating system update, as after the update other packages could depend on the custom packages and thus it might not be possible to autoremove them.
+
 ## System setup
 
 Independently of how it was installed the recording server needs to be configured. Depending on the setup additional components like a firewall might also need to be setup or adjusted.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,9 +59,9 @@ Pin-Priority: 1001
 ' | sudo tee /etc/apt/preferences.d/mozilla-firefox
 ```
 
-#### Ubuntu 22.04
+#### Ubuntu 22.04 and later
 
-In Ubuntu 22.04 the normal Firefox package was replaced by a Snap. Unfortunately the Snap package can not be used with the default packages, so the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages (`add-apt-repository` is included in the package `software-properties-common`):
+In Ubuntu 22.04 and later the normal Firefox package was replaced by a Snap. Unfortunately the Snap package can not be used with the default packages, so the [PPA from Mozilla](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) needs to be setup instead before installing the packages (`add-apt-repository` is included in the package `software-properties-common`):
 ```
 add-apt-repository ppa:mozillateam/ppa
 ```
@@ -127,7 +127,7 @@ The configuration file must be edited to set the Nextcloud servers that are allo
 
 The temporary directory where the videos are stored while being recorded (and if they fail to be uploaded to the Nextcloud server) is `/tmp/`. That directory is typically a temporary file system stored in RAM, so depending on the available RAM and the number of simultaneous recordings it could affect the system or cause some recordings to suddenly fail due to running out of space. This can be customized in `backend->directory` to use a more suitable directory (for example, a directory under the home directory of the user running the recording server).
 
-In Debian 13, if the Selenium package provided by the distribution is used (which it is by default in the pre-built packages and in the packages built with the _build.sh_ script), the Selenium Manager will not be available, so the path to the Selenium driver must be set in `recording->driverPath`. The path to the Selenium driver provided by the default Firefox package is `/usr/bin/geckodriver`.
+In Debian 13 and Ubuntu 24.04, if the Selenium package provided by the distribution is used (which it is by default in the pre-built packages and in the packages built with the _build.sh_ script), the Selenium Manager will not be available, so the path to the Selenium driver must be set in `recording->driverPath`. The path to the Selenium driver provided by the default Firefox package is `/usr/bin/geckodriver`.
 
 By default the recording server listens for HTTP requests on `127.0.0.1:8000`. [As described below](#tls-termination-proxy) it is recommended to set up a TLS termination proxy in front of the recording server, and this TLS termination proxy is the one expected to listen on public interfaces. If needed, the IP and port to listen on for HTTP requests can be customized in `http->listen`.
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -34,8 +34,12 @@ download-source-python-package = python3 -m pip download --dest $(BUILD_DIR) --n
 extract-source-python-package = cd $(BUILD_DIR) && tar --extract --gzip --file $(1)-$(2).tar.gz
 
 # Since the 60.0.0 release, Setuptools includes a local, vendored copy of
-# distutils; this copy does not seem to work with stdeb, so it needs to be
-# disabled with "SETUPTOOLS_USE_DISTUTILS=stdlib".
+# distutils. stdeb calls setup.py with "--install-layout=deb", which is only
+# supported in patched distutils. Debian and Ubuntu explicitly patch distutils
+# in stdlib to support it, and in some versions they also implicitly patch
+# distutils at runtime, independently of where it comes from (through
+# "_distutils_system.mod.py"). However, when distutils provided by Setuptools
+# does not support the option distutils from stdlib needs to be used instead.
 build-deb-package = cd $(BUILD_DIR)/$(1)-$(2)/ && SOURCE_DATE_EPOCH=$(3) SETUPTOOLS_USE_DISTUTILS=stdlib python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $(DEBIAN_VERSION) bdist_deb
 
 copy-binary-deb-package = cp $(BUILD_DIR)/$(1)-$(2)/deb_dist/$(3)_$(2)-$(DEBIAN_VERSION)_all.deb $(BUILD_DIR)/deb/

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -23,6 +23,15 @@ TRIO_VERSION := 0.21.0
 TRIO_WEBSOCKET_VERSION := 0.9.2
 URLLIB3_VERSION := 1.26.19
 
+# Since the 60.0.0 release, Setuptools includes a local, vendored copy of
+# distutils. stdeb calls setup.py with "--install-layout=deb", which is only
+# supported in patched distutils. Debian and Ubuntu explicitly patch distutils
+# in stdlib to support it, and in some versions they also implicitly patch
+# distutils at runtime, independently of where it comes from (through
+# "_distutils_system.mod.py"). However, when distutils provided by Setuptools
+# does not support the option distutils from stdlib needs to be used instead.
+SETUPTOOLS_USE_DISTUTILS := SETUPTOOLS_USE_DISTUTILS=stdlib
+
 timestamp-from-git = git log -1 --pretty=%ct $(1)
 
 timestamp-from-source-python-package = tar --list --verbose --full-time --gzip --file $(1) | head --lines 1 | sed 's/ \+/ /g' | cut --delimiter " " --fields 4-5 | date --file - +%s
@@ -33,14 +42,7 @@ download-source-python-package = python3 -m pip download --dest $(BUILD_DIR) --n
 
 extract-source-python-package = cd $(BUILD_DIR) && tar --extract --gzip --file $(1)-$(2).tar.gz
 
-# Since the 60.0.0 release, Setuptools includes a local, vendored copy of
-# distutils. stdeb calls setup.py with "--install-layout=deb", which is only
-# supported in patched distutils. Debian and Ubuntu explicitly patch distutils
-# in stdlib to support it, and in some versions they also implicitly patch
-# distutils at runtime, independently of where it comes from (through
-# "_distutils_system.mod.py"). However, when distutils provided by Setuptools
-# does not support the option distutils from stdlib needs to be used instead.
-build-deb-package = cd $(BUILD_DIR)/$(1)-$(2)/ && SOURCE_DATE_EPOCH=$(3) SETUPTOOLS_USE_DISTUTILS=stdlib python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $(DEBIAN_VERSION) bdist_deb
+build-deb-package = cd $(BUILD_DIR)/$(1)-$(2)/ && SOURCE_DATE_EPOCH=$(3) $(SETUPTOOLS_USE_DISTUTILS) python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $(DEBIAN_VERSION) bdist_deb
 
 copy-binary-deb-package = cp $(BUILD_DIR)/$(1)-$(2)/deb_dist/$(3)_$(2)-$(DEBIAN_VERSION)_all.deb $(BUILD_DIR)/deb/
 
@@ -87,7 +89,7 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 
 	# Build a source Debian package (with the systemd addon for dh) and then,
 	# from it, a binary Debian package.
-	cd $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/ && SOURCE_DATE_EPOCH=$$($(call timestamp-from-git,../../../../)) SETUPTOOLS_USE_DISTUTILS=stdlib python3 setup.py --command-packages=stdeb.command sdist_dsc --with-dh-systemd --debian-version $(DEBIAN_VERSION) bdist_deb
+	cd $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/ && SOURCE_DATE_EPOCH=$$($(call timestamp-from-git,../../../../)) $(SETUPTOOLS_USE_DISTUTILS) python3 setup.py --command-packages=stdeb.command sdist_dsc --with-dh-systemd --debian-version $(DEBIAN_VERSION) bdist_deb
 
 	$(call copy-binary-deb-package,nextcloud_talk_recording,$(NEXTCLOUD_TALK_RECORDING_VERSION),nextcloud-talk-recording)
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -90,6 +90,7 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 # Builds the Python dependencies that are not included in at least one of the
 # supported distributions:
 # - Debian 11 (bullseye): pulsectl, pyvirtualdisplay >= 2.0, selenium >= 4.11.0
+# - Debian 12 (bookworm): selenium >= 4.11.0
 # - Ubuntu 20.04 (focal): pulsectl, pyvirtualdisplay >= 2.0, requests >= 2.25, selenium >= 4.11.0
 # - Ubuntu 22.04 (jammy): pulsectl, selenium >= 4.11.0
 #
@@ -98,6 +99,7 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 build-packages-deb-nextcloud-talk-recording-dependencies: build-packages-deb-nextcloud-talk-recording-dependencies-$(OS_VERSION)
 
 build-packages-deb-nextcloud-talk-recording-dependencies-debian11: build-packages-deb-pulsectl build-packages-deb-pyvirtualdisplay build-packages-deb-selenium build-packages-deb-selenium-dependencies
+build-packages-deb-nextcloud-talk-recording-dependencies-debian12: build-packages-deb-selenium
 build-packages-deb-nextcloud-talk-recording-dependencies-ubuntu20.04: build-packages-deb-pulsectl build-packages-deb-pyvirtualdisplay build-packages-deb-requests build-packages-deb-requests-dependencies build-packages-deb-selenium build-packages-deb-selenium-dependencies
 build-packages-deb-nextcloud-talk-recording-dependencies-ubuntu22.04: build-packages-deb-pulsectl build-packages-deb-selenium build-packages-deb-selenium-dependencies
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -34,6 +34,16 @@ ifeq ($(OS_VERSION),$(filter $(OS_VERSION),debian11 ubuntu20.04))
 	SETUPTOOLS_USE_DISTUTILS := SETUPTOOLS_USE_DISTUTILS=stdlib
 endif
 
+# stdeb provides "--with-dh-systemd" to enable the systemd addon for debhelper.
+# In debhelper compatibility level 10 the addon was enabled by default, and in
+# level 11 it was removed and replaced by dh_installsystemd (which is also
+# included in the standard dh sequence). Therefore "--with-dh-systemd" is only
+# needed in stdeb < 0.11.0, as in 0.11.0 the compatibility level was raised from
+# 9 to 12.
+ifeq ($(OS_VERSION),$(filter $(OS_VERSION),debian11 debian12 debian13 ubuntu20.04 ubuntu22.04))
+	WITH_DH_SYSTEMD := --with-dh-systemd
+endif
+
 timestamp-from-git = git log -1 --pretty=%ct $(1)
 
 timestamp-from-source-python-package = tar --list --verbose --full-time --gzip --file $(1) | head --lines 1 | sed 's/ \+/ /g' | cut --delimiter " " --fields 4-5 | date --file - +%s
@@ -89,9 +99,9 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 	cp --recursive nextcloud-talk-recording/. $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/
 	cp ../server.conf.in $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/
 
-	# Build a source Debian package (with the systemd addon for dh) and then,
-	# from it, a binary Debian package.
-	cd $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/ && SOURCE_DATE_EPOCH=$$($(call timestamp-from-git,../../../../)) $(SETUPTOOLS_USE_DISTUTILS) python3 setup.py --command-packages=stdeb.command sdist_dsc --with-dh-systemd --debian-version $(DEBIAN_VERSION) bdist_deb
+	# Build a source Debian package (with the systemd addon for dh, if
+	# needed) and then, from it, a binary Debian package.
+	cd $(BUILD_DIR)/nextcloud_talk_recording-$(NEXTCLOUD_TALK_RECORDING_VERSION)/ && SOURCE_DATE_EPOCH=$$($(call timestamp-from-git,../../../../)) $(SETUPTOOLS_USE_DISTUTILS) python3 setup.py --command-packages=stdeb.command sdist_dsc $(WITH_DH_SYSTEMD) --debian-version $(DEBIAN_VERSION) bdist_deb
 
 	$(call copy-binary-deb-package,nextcloud_talk_recording,$(NEXTCLOUD_TALK_RECORDING_VERSION),nextcloud-talk-recording)
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -99,6 +99,7 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 # supported distributions:
 # - Debian 11 (bullseye): pulsectl, pyvirtualdisplay >= 2.0, selenium >= 4.11.0
 # - Debian 12 (bookworm): selenium >= 4.11.0
+# - Debian 13 (trixie):
 # - Ubuntu 20.04 (focal): pulsectl, pyvirtualdisplay >= 2.0, requests >= 2.25, selenium >= 4.11.0
 # - Ubuntu 22.04 (jammy): pulsectl, selenium >= 4.11.0
 #
@@ -108,6 +109,7 @@ build-packages-deb-nextcloud-talk-recording-dependencies: build-packages-deb-nex
 
 build-packages-deb-nextcloud-talk-recording-dependencies-debian11: build-packages-deb-pulsectl build-packages-deb-pyvirtualdisplay build-packages-deb-selenium build-packages-deb-selenium-dependencies
 build-packages-deb-nextcloud-talk-recording-dependencies-debian12: build-packages-deb-selenium
+build-packages-deb-nextcloud-talk-recording-dependencies-debian13:
 build-packages-deb-nextcloud-talk-recording-dependencies-ubuntu20.04: build-packages-deb-pulsectl build-packages-deb-pyvirtualdisplay build-packages-deb-requests build-packages-deb-requests-dependencies build-packages-deb-selenium build-packages-deb-selenium-dependencies
 build-packages-deb-nextcloud-talk-recording-dependencies-ubuntu22.04: build-packages-deb-pulsectl build-packages-deb-selenium build-packages-deb-selenium-dependencies
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -88,7 +88,7 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 	$(call copy-binary-deb-package,nextcloud_talk_recording,$(NEXTCLOUD_TALK_RECORDING_VERSION),nextcloud-talk-recording)
 
 # Builds the Python dependencies that are not included in at least one of the
-# Ubuntu supported releases:
+# supported distributions:
 # - Debian 11 (bullseye): pulsectl, pyvirtualdisplay >= 2.0, selenium >= 4.11.0
 # - Ubuntu 20.04 (focal): pulsectl, pyvirtualdisplay >= 2.0, requests >= 2.25, selenium >= 4.11.0
 # - Ubuntu 22.04 (jammy): pulsectl, selenium >= 4.11.0
@@ -129,7 +129,7 @@ $(BUILD_DIR)/deb/python3-requests_$(REQUESTS_VERSION)-$(DEBIAN_VERSION)_all.deb:
 	$(call copy-binary-deb-package,requests,$(REQUESTS_VERSION),python3-requests)
 
 # Builds the Python dependencies that are not included in at least one of the
-# Ubuntu supported releases:
+# supported distributions:
 # - Debian 11 (bullseye): unneeded, uses requests package from distribution
 # - Ubuntu 20.04 (focal): charset-normalizer >= 2, < 4
 # - Ubuntu 22.04 (jammy): unneeded, uses requests package from distribution
@@ -168,7 +168,7 @@ $(BUILD_DIR)/deb/python3-selenium_$(SELENIUM_VERSION)-$(DEBIAN_VERSION)_all.deb:
 	$(call copy-binary-deb-package,selenium,$(SELENIUM_VERSION),python3-selenium)
 
 # Builds the Python dependencies that are not included in at least one of the
-# Ubuntu supported releases:
+# supported distributions:
 # - Debian 11 (bullseye): python3-certifi >= 2021.10.8, python3-trio ~= 0.17, python3-trio-websocket ~= 0.9
 # - Ubuntu 20.04 (focal): python3-certifi >= 2021.10.8, python3-trio ~= 0.17, python3-trio-websocket ~= 0.9, python3-urllib3 >= 1.26, < 3
 # - Ubuntu 22.04 (jammy): python3-certifi >= 2021.10.8, python3-trio-websocket ~= 0.9

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -112,6 +112,7 @@ $(BUILD_DIR)/deb/nextcloud-talk-recording_$(NEXTCLOUD_TALK_RECORDING_VERSION)-$(
 # - Debian 13 (trixie):
 # - Ubuntu 20.04 (focal): pulsectl, pyvirtualdisplay >= 2.0, requests >= 2.25, selenium >= 4.11.0
 # - Ubuntu 22.04 (jammy): pulsectl, selenium >= 4.11.0
+# - Ubuntu 24.04 (noble):
 #
 # requests < 2.25 is not compatible with urllib3 >= 1.26, which is required by
 # selenium.
@@ -122,6 +123,7 @@ build-packages-deb-nextcloud-talk-recording-dependencies-debian12: build-package
 build-packages-deb-nextcloud-talk-recording-dependencies-debian13:
 build-packages-deb-nextcloud-talk-recording-dependencies-ubuntu20.04: build-packages-deb-pulsectl build-packages-deb-pyvirtualdisplay build-packages-deb-requests build-packages-deb-requests-dependencies build-packages-deb-selenium build-packages-deb-selenium-dependencies
 build-packages-deb-nextcloud-talk-recording-dependencies-ubuntu22.04: build-packages-deb-pulsectl build-packages-deb-selenium build-packages-deb-selenium-dependencies
+build-packages-deb-nextcloud-talk-recording-dependencies-ubuntu24.04:
 
 build-packages-deb-pulsectl: $(BUILD_DIR)/deb/python3-pulsectl_$(PULSECTL_VERSION)-$(DEBIAN_VERSION)_all.deb
 $(BUILD_DIR)/deb/python3-pulsectl_$(PULSECTL_VERSION)-$(DEBIAN_VERSION)_all.deb: | $(BUILD_DIR)/deb

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -30,7 +30,9 @@ URLLIB3_VERSION := 1.26.19
 # distutils at runtime, independently of where it comes from (through
 # "_distutils_system.mod.py"). However, when distutils provided by Setuptools
 # does not support the option distutils from stdlib needs to be used instead.
-SETUPTOOLS_USE_DISTUTILS := SETUPTOOLS_USE_DISTUTILS=stdlib
+ifeq ($(OS_VERSION),$(filter $(OS_VERSION),debian11 ubuntu20.04))
+	SETUPTOOLS_USE_DISTUTILS := SETUPTOOLS_USE_DISTUTILS=stdlib
+endif
 
 timestamp-from-git = git log -1 --pretty=%ct $(1)
 

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -91,7 +91,7 @@ trap cleanUp EXIT
 # the volumes in the container) expect that.
 cd "$(dirname $0)"
 
-SUPPORTED_TARGETS="debian11 debian12 debian13 ubuntu20.04 ubuntu22.04"
+SUPPORTED_TARGETS="debian11 debian12 debian13 ubuntu20.04 ubuntu22.04 ubuntu24.04"
 
 HELP="Usage: $(basename $0) [OPTION]...
 
@@ -196,12 +196,28 @@ function setupBuildEnvironmentInUbuntu2204() {
 	docker exec $CONTAINER-ubuntu22.04 bash -c "apt-get install --assume-yes pulseaudio python3-async-generator python3-trio python3-wsproto"
 }
 
+function setupBuildEnvironmentInUbuntu2404() {
+	echo "Installing required build dependencies"
+	# "noninteractive" is used to provide default settings instead of asking for
+	# them (for example, for tzdata).
+	docker exec $CONTAINER-ubuntu24.04 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-pip python3-venv python3-build python3-setuptools python3-all debhelper dh-python git dh-exec"
+	# stdeb was not compatible with Python >= 3.12 until version 0.11.0, so the
+	# Ubuntu 24.04 package of stdeb can not be used; note that the pull request
+	# mentions Python >= 3.11, but the mentioned change was reverted and finally
+	# applied only for Python > 3.12:
+	# https://github.com/astraw/stdeb/pull/196
+	# https://github.com/python/cpython/pull/30952
+	# https://github.com/python/cpython/pull/92503
+	docker exec $CONTAINER-ubuntu24.04 bash -c "python3 -m pip install 'stdeb >= 0.11' --break-system-packages"
+}
+
 declare -A TARGET_NAMES
 TARGET_NAMES["debian11"]="Debian 11"
 TARGET_NAMES["debian12"]="Debian 12"
 TARGET_NAMES["debian13"]="Debian 13"
 TARGET_NAMES["ubuntu20.04"]="Ubuntu 20.04"
 TARGET_NAMES["ubuntu22.04"]="Ubuntu 22.04"
+TARGET_NAMES["ubuntu24.04"]="Ubuntu 24.04"
 
 declare -A TARGET_IMAGES
 TARGET_IMAGES["debian11"]="debian:11"
@@ -209,6 +225,7 @@ TARGET_IMAGES["debian12"]="debian:12"
 TARGET_IMAGES["debian13"]="debian:13"
 TARGET_IMAGES["ubuntu20.04"]="ubuntu:20.04"
 TARGET_IMAGES["ubuntu22.04"]="ubuntu:22.04"
+TARGET_IMAGES["ubuntu24.04"]="ubuntu:24.04"
 
 declare -A TARGET_SETUP_FUNCTIONS
 TARGET_SETUP_FUNCTIONS["debian11"]="setupBuildEnvironmentInDebian11"
@@ -216,6 +233,7 @@ TARGET_SETUP_FUNCTIONS["debian12"]="setupBuildEnvironmentInDebian12"
 TARGET_SETUP_FUNCTIONS["debian13"]="setupBuildEnvironmentInDebian13"
 TARGET_SETUP_FUNCTIONS["ubuntu20.04"]="setupBuildEnvironmentInUbuntu2004"
 TARGET_SETUP_FUNCTIONS["ubuntu22.04"]="setupBuildEnvironmentInUbuntu2204"
+TARGET_SETUP_FUNCTIONS["ubuntu24.04"]="setupBuildEnvironmentInUbuntu2404"
 
 # If the containers are not found new ones are prepared. Otherwise the existing
 # containers are used.

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -91,7 +91,7 @@ trap cleanUp EXIT
 # the volumes in the container) expect that.
 cd "$(dirname $0)"
 
-SUPPORTED_TARGETS="debian11 debian12 ubuntu20.04 ubuntu22.04"
+SUPPORTED_TARGETS="debian11 debian12 debian13 ubuntu20.04 ubuntu22.04"
 
 HELP="Usage: $(basename $0) [OPTION]...
 
@@ -158,6 +158,16 @@ function setupBuildEnvironmentInDebian12() {
 	docker exec $CONTAINER-debian12 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-pip python3-venv python3-build python3-stdeb python3-all debhelper dh-python git dh-exec"
 }
 
+function setupBuildEnvironmentInDebian13() {
+	echo "Installing required build dependencies"
+	# "noninteractive" is used to provide default settings instead of asking for
+	# them (for example, for tzdata).
+	# stdeb was not compatible with Python >= 3.12 until version 0.11.0, but
+	# Debian 13 package of stdeb 0.10.0 is patched to make it compatible:
+	# https://sources.debian.org/patches/stdeb/0.10.0-5/0005-Migrate-off-SafeConfigParser.patch/
+	docker exec $CONTAINER-debian13 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-venv python3-build python3-stdeb python3-all debhelper dh-python git dh-exec"
+}
+
 function setupBuildEnvironmentInUbuntu2004() {
 	echo "Installing required build dependencies"
 	# "noninteractive" is used to provide default settings instead of asking for
@@ -189,18 +199,21 @@ function setupBuildEnvironmentInUbuntu2204() {
 declare -A TARGET_NAMES
 TARGET_NAMES["debian11"]="Debian 11"
 TARGET_NAMES["debian12"]="Debian 12"
+TARGET_NAMES["debian13"]="Debian 13"
 TARGET_NAMES["ubuntu20.04"]="Ubuntu 20.04"
 TARGET_NAMES["ubuntu22.04"]="Ubuntu 22.04"
 
 declare -A TARGET_IMAGES
 TARGET_IMAGES["debian11"]="debian:11"
 TARGET_IMAGES["debian12"]="debian:12"
+TARGET_IMAGES["debian13"]="debian:13"
 TARGET_IMAGES["ubuntu20.04"]="ubuntu:20.04"
 TARGET_IMAGES["ubuntu22.04"]="ubuntu:22.04"
 
 declare -A TARGET_SETUP_FUNCTIONS
 TARGET_SETUP_FUNCTIONS["debian11"]="setupBuildEnvironmentInDebian11"
 TARGET_SETUP_FUNCTIONS["debian12"]="setupBuildEnvironmentInDebian12"
+TARGET_SETUP_FUNCTIONS["debian13"]="setupBuildEnvironmentInDebian13"
 TARGET_SETUP_FUNCTIONS["ubuntu20.04"]="setupBuildEnvironmentInUbuntu2004"
 TARGET_SETUP_FUNCTIONS["ubuntu22.04"]="setupBuildEnvironmentInUbuntu2204"
 

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -91,7 +91,7 @@ trap cleanUp EXIT
 # the volumes in the container) expect that.
 cd "$(dirname $0)"
 
-SUPPORTED_TARGETS="debian11 ubuntu20.04 ubuntu22.04"
+SUPPORTED_TARGETS="debian11 debian12 ubuntu20.04 ubuntu22.04"
 
 HELP="Usage: $(basename $0) [OPTION]...
 
@@ -151,6 +151,13 @@ function setupBuildEnvironmentInDebian11() {
 	docker exec $CONTAINER-debian11 bash -c "python3 -m pip install 'stdeb < 0.11.0' build 'setuptools >= 61.0'"
 }
 
+function setupBuildEnvironmentInDebian12() {
+	echo "Installing required build dependencies"
+	# "noninteractive" is used to provide default settings instead of asking for
+	# them (for example, for tzdata).
+	docker exec $CONTAINER-debian12 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes make python3 python3-pip python3-venv python3-build python3-stdeb python3-all debhelper dh-python git dh-exec"
+}
+
 function setupBuildEnvironmentInUbuntu2004() {
 	echo "Installing required build dependencies"
 	# "noninteractive" is used to provide default settings instead of asking for
@@ -181,16 +188,19 @@ function setupBuildEnvironmentInUbuntu2204() {
 
 declare -A TARGET_NAMES
 TARGET_NAMES["debian11"]="Debian 11"
+TARGET_NAMES["debian12"]="Debian 12"
 TARGET_NAMES["ubuntu20.04"]="Ubuntu 20.04"
 TARGET_NAMES["ubuntu22.04"]="Ubuntu 22.04"
 
 declare -A TARGET_IMAGES
 TARGET_IMAGES["debian11"]="debian:11"
+TARGET_IMAGES["debian12"]="debian:12"
 TARGET_IMAGES["ubuntu20.04"]="ubuntu:20.04"
 TARGET_IMAGES["ubuntu22.04"]="ubuntu:22.04"
 
 declare -A TARGET_SETUP_FUNCTIONS
 TARGET_SETUP_FUNCTIONS["debian11"]="setupBuildEnvironmentInDebian11"
+TARGET_SETUP_FUNCTIONS["debian12"]="setupBuildEnvironmentInDebian12"
 TARGET_SETUP_FUNCTIONS["ubuntu20.04"]="setupBuildEnvironmentInUbuntu2004"
 TARGET_SETUP_FUNCTIONS["ubuntu22.04"]="setupBuildEnvironmentInUbuntu2204"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,16 @@
 [project]
 name = "nextcloud-talk-recording"
 description = "Recording server for Nextcloud Talk"
+# The "readme" entry is not meant for PyPi, but for stdeb, which appends it to
+# the package description. However, stdeb does not convert markdown syntax, so
+# for now instead of linking to the actual README.md file a slightly simplified
+# plain text version is used.
+readme.text = """
+This is the official recording server to be used with Nextcloud Talk (https://github.com/nextcloud/spreed).
+
+It requires the standalone signaling server for Nextcloud Talk (https://github.com/strukturag/nextcloud-spreed-signaling).
+"""
+readme.content-type = "text/plain"
 authors = [
     { name = "Nextcloud Talk Team" },
 ]

--- a/server.conf.in
+++ b/server.conf.in
@@ -152,7 +152,9 @@
 # Manager will try to find the right one in $PATH, downloading it as a fallback.
 # Note that Selenium Manager does not work in some architectures (for example,
 # Linux on arm64/aarch64), so in those architectures the driver must be
-# explicitly set.
+# explicitly set. The driver must be explicitly set if Selenium Manager is not
+# available either in the system for any reason, even if the architecture is
+# compatible.
 #driverPath =
 
 # Path to the browser executable to use for recordings.
@@ -162,9 +164,10 @@
 # installed Selenium version if the executable is not found Selenium Manager may
 # also download the browser as a fallback.
 # Note that Selenium Manager does not work in some architectures (for example,
-# Linux on arm64/aarch64); in those architectures the Selenium driver will try
-# to find the executable, but the executable may need to be explicitly set if
-# not found by the driver.
+# Linux on arm64/aarch64); in those architectures (or if Selenium Manager is not
+# available in the system for any reason, even if the architecture is
+# compatible) the Selenium driver will try to find the executable, but the
+# executable may need to be explicitly set if not found by the driver.
 #browserPath =
 
 [stats]


### PR DESCRIPTION
Fixes #31

Debian 13 and Ubuntu 24.04 finally provide all the needed Python dependencies, so no custom packages for them need to be built. Unfortunately the _python3-selenium_ package does not include Selenium Manager (and it seems that [it will not include it either in future versions](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1051368), but that might of course change), so the path to the Selenium driver to use needs to be [explicitly configured in `recording->driverPath`](https://github.com/nextcloud/nextcloud-talk-recording/blob/98c49982de35dfa85a442bcd16f304dcb22bb427/server.conf.in#L156) (`/usr/bin/geckodriver` for Firefox, `/usr/bin/chromedriver` for Chrome).

Besides that, the version of PulseAudio in Debian 12, Debian 13 and Ubuntu 24.04 is >= 15.99.1, so [they all suffer some audio delay even if their ffmpeg version is >= 5.1](https://github.com/nextcloud/nextcloud-talk-recording/issues/9#issuecomment-3707773947). Unfortunately it is not known how to fix or at least work around that yet.