### PR TITLE
Use backend ID as backend label in Prometheus metrics

### DIFF
--- a/docs/prometheus-metrics.md
+++ b/docs/prometheus-metrics.md
@@ -20,6 +20,8 @@ The following metrics are available:
 | `recording_recordings_total`                      | Counter   | 0.2.0     | The total number of recordings                                                                         | `backend`                         |
 | `recording_recordings_duration_seconds_total`     | Counter   | 0.2.0     | The total duration of all recordings, see [notes](#recording_recordings_duration_seconds_total)        | `backend`                         |
 
+- The value of the `backend` label is the identifier for the backend (its corresponding section name) used in the configuration file of the recording server or, if `allowall` is set and the backend is not explicitly configured, the URL of the backend.
+
 ### Notes
 
 #### Integer values

--- a/src/nextcloud/talk/recording/BackendNotifier.py
+++ b/src/nextcloud/talk/recording/BackendNotifier.py
@@ -24,14 +24,14 @@ from .Config import config
 
 logger = logging.getLogger(__name__)
 
-def getRandomAndChecksum(backend, data):
+def getRandomAndChecksum(backendUrl, data):
     """
     Returns a random string and the checksum of the given data with that random.
 
-    :param backend: the backend to send the data to.
+    :param backendUrl: the URL of the backend to send the data to.
     :param data: the data, as bytes.
     """
-    secret = config.getBackendSecret(backend).encode()
+    secret = config.getBackendSecret(backendUrl).encode()
     random = token_urlsafe(64)
     hmacValue = hmac.new(secret, random.encode() + data, hashlib.sha256)
 
@@ -49,18 +49,18 @@ def _isClientError(exception):
 
     return 400 <= exception.response.status_code < 500
 
-def doRequest(backend, request, retries=3):
+def doRequest(backendUrl, request, retries=3):
     """
     Send the request to the backend.
 
     SSL verification will be skipped if configured.
 
-    :param backend: the backend to send the request to.
+    :param backendUrl: the URL of the backend to send the request to.
     :param request: the request to send.
     :param retries: the number of times to retry in case of failure.
     :returns: the response of the request.
     """
-    backendSkipVerify = config.getBackendSkipVerify(backend)
+    backendSkipVerify = config.getBackendSkipVerify(backendUrl)
 
     try:
         session = Session()
@@ -74,12 +74,12 @@ def doRequest(backend, request, retries=3):
         # fail again and is therefore pointless.
         if retries > 1 and not _isClientError(exception):
             logger.exception("Failed to send message to backend, %d retries left!", retries)
-            return doRequest(backend, request, retries - 1)
+            return doRequest(backendUrl, request, retries - 1)
 
         logger.exception("Failed to send message to backend, giving up!")
         raise
 
-def backendRequest(backend, data):
+def backendRequest(backendUrl, data):
     """
     Sends the data to the backend on the endpoint to receive notifications from
     the recording server.
@@ -87,14 +87,14 @@ def backendRequest(backend, data):
     The data is automatically wrapped in a request for the appropriate URL and
     with the needed headers.
 
-    :param backend: the backend to send the data to.
+    :param backendUrl: the URL of the backend to send the data to.
     :param data: the data to send.
     """
-    url = backend.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/backend'
+    url = backendUrl.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/backend'
 
     data = json.dumps(data).encode()
 
-    random, checksum = getRandomAndChecksum(backend, data)
+    random, checksum = getRandomAndChecksum(backendUrl, data)
 
     headers = {
         'Content-Type': 'application/json',
@@ -106,13 +106,13 @@ def backendRequest(backend, data):
 
     request = Request('POST', url, headers, data=data)
 
-    doRequest(backend, request)
+    doRequest(backendUrl, request)
 
-def started(backend, token, status, actorType, actorId):
+def started(backendUrl, token, status, actorType, actorId):
     """
     Notifies the backend that the recording was started.
 
-    :param backend: the backend of the conversation.
+    :param backendUrl: the URL of the backend of the conversation.
     :param token: the token of the conversation.
     :param actorType: the actor type of the Talk participant that started the
            recording.
@@ -120,7 +120,7 @@ def started(backend, token, status, actorType, actorId):
            recording.
     """
 
-    backendRequest(backend, {
+    backendRequest(backendUrl, {
         'type': 'started',
         'started': {
             'token': token,
@@ -132,11 +132,11 @@ def started(backend, token, status, actorType, actorId):
         },
     })
 
-def stopped(backend, token, actorType, actorId):
+def stopped(backendUrl, token, actorType, actorId):
     """
     Notifies the backend that the recording was stopped.
 
-    :param backend: the backend of the conversation.
+    :param backendUrl: the URL of the backend of the conversation.
     :param token: the token of the conversation.
     :param actorType: the actor type of the Talk participant that stopped the
            recording.
@@ -157,13 +157,13 @@ def stopped(backend, token, actorType, actorId):
             'id': actorId,
         }
 
-    backendRequest(backend, data)
+    backendRequest(backendUrl, data)
 
-def failed(backend, token):
+def failed(backendUrl, token):
     """
     Notifies the backend that the recording failed.
 
-    :param backend: the backend of the conversation.
+    :param backendUrl: the URL of the backend of the conversation.
     :param token: the token of the conversation.
     """
 
@@ -174,9 +174,9 @@ def failed(backend, token):
         },
     }
 
-    backendRequest(backend, data)
+    backendRequest(backendUrl, data)
 
-def uploadRecording(backend, token, fileName, owner):
+def uploadRecording(backendUrl, token, fileName, owner):
     """
     Upload the recording specified by fileName.
 
@@ -187,32 +187,32 @@ def uploadRecording(backend, token, fileName, owner):
     limits enforced on a regular request. Otherwise the recording is uploaded
     directly in a single request as a fallback for older backends.
 
-    :param backend: the backend to upload the file to.
+    :param backendUrl: the URL of the backend to upload the file to.
     :param token: the token of the conversation that was recorded.
     :param fileName: the recording file name.
     :param owner: the owner of the uploaded file.
     """
 
-    logger.info("Upload recording %s to %s in %s as %s", fileName, backend, token, owner)
+    logger.info("Upload recording %s to %s in %s as %s", fileName, backendUrl, token, owner)
 
-    uploadShare = requestUpload(backend, token, fileName, owner)
+    uploadShare = requestUpload(backendUrl, token, fileName, owner)
 
     if uploadShare is None:
         # The backend does not support chunked uploads or public link sharing is
         # disabled. Fall back to directly uploading the recording in a single
         # request.
-        uploadRecordingDirectly(backend, token, fileName, owner)
+        uploadRecordingDirectly(backendUrl, token, fileName, owner)
 
         return
 
-    uploadRecordingInChunks(backend, uploadShare, fileName)
+    uploadRecordingInChunks(backendUrl, uploadShare, fileName)
 
     # Once the recording was uploaded and assembled the store endpoint is called
     # with its file name to trigger the post-processing and the notification for
     # the moderators.
-    store(backend, token, uploadShare['fileName'], owner)
+    store(backendUrl, token, uploadShare['fileName'], owner)
 
-def requestUpload(backend, token, fileName, owner):
+def requestUpload(backendUrl, token, fileName, owner):
     """
     Requests a temporary upload share to upload a recording in chunks.
 
@@ -222,13 +222,13 @@ def requestUpload(backend, token, fileName, owner):
     the backend does not allow them, for example if public sharing is disabled
     (400).
 
-    :param backend: the backend to request the upload share from.
+    :param backendUrl: the URL of the backend to request the upload share from.
     :param token: the token of the conversation that was recorded.
     :param fileName: the recording file name.
     :param owner: the owner of the uploaded file.
     """
 
-    url = backend.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/request-upload'
+    url = backendUrl.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/request-upload'
 
     data = json.dumps({
         'owner': owner,
@@ -237,7 +237,7 @@ def requestUpload(backend, token, fileName, owner):
 
     # The checksum is calculated from the conversation token, like in the other
     # recording endpoints.
-    random, checksum = getRandomAndChecksum(backend, token.encode())
+    random, checksum = getRandomAndChecksum(backendUrl, token.encode())
 
     headers = {
         'Content-Type': 'application/json',
@@ -251,16 +251,16 @@ def requestUpload(backend, token, fileName, owner):
     request = Request('POST', url, headers, data=data)
 
     try:
-        response = doRequest(backend, request)
+        response = doRequest(backendUrl, request)
     except HTTPError as httpError:
         if httpError.response is not None and httpError.response.status_code == 404:
-            logger.info("Backend %s does not support chunked recording uploads, uploading directly", backend)
+            logger.info("Backend %s does not support chunked recording uploads, uploading directly", backendUrl)
 
             return None
 
         if httpError.response is not None and httpError.response.status_code == 400:
             logger.info("Backend %s does not allow chunked recording uploads (public sharing may be "
-                        "disabled), uploading directly", backend)
+                        "disabled), uploading directly", backendUrl)
 
             return None
 
@@ -268,20 +268,20 @@ def requestUpload(backend, token, fileName, owner):
 
     return response.json()['ocs']['data']
 
-def uploadRecordingInChunks(backend, uploadShare, fileName):
+def uploadRecordingInChunks(backendUrl, uploadShare, fileName):
     """
     Uploads the recording specified by fileName in chunks to an upload share.
 
     The recording is uploaded through the chunked public WebDAV API, using the
     upload share token as the user and its password as the password.
 
-    :param backend: the backend to upload the file to.
+    :param backendUrl: the URL of the backend to upload the file to.
     :param uploadShare: the data of the upload share ("token", "password" and
            "fileName") as returned by requestUpload().
     :param fileName: the recording file name.
     """
 
-    backendUrl = backend.rstrip('/')
+    backendUrl = backendUrl.rstrip('/')
 
     shareToken = uploadShare['token']
     sharePassword = uploadShare['password']
@@ -304,12 +304,12 @@ def uploadRecordingInChunks(backend, uploadShare, fileName):
     }
 
     # Initialize the chunked upload.
-    doRequest(backend, Request('MKCOL', uploadUrl, headers, auth=auth))
+    doRequest(backendUrl, Request('MKCOL', uploadUrl, headers, auth=auth))
 
     # Upload the recording in chunks. Chunks are named with sequential numbers
     # starting at 1, which is the order in which they are assembled into the
     # final file.
-    chunkSize = config.getBackendUploadChunkSize(backend)
+    chunkSize = config.getBackendUploadChunkSize(backendUrl)
     chunkNumber = 0
     with open(fileName, 'rb') as fileToUpload:
         while True:
@@ -320,23 +320,23 @@ def uploadRecordingInChunks(backend, uploadShare, fileName):
             chunkNumber += 1
             chunkUrl = uploadUrl + '/' + str(chunkNumber)
 
-            doRequest(backend, Request('PUT', chunkUrl, headers, data=chunk, auth=auth))
+            doRequest(backendUrl, Request('PUT', chunkUrl, headers, data=chunk, auth=auth))
 
     # Assemble the uploaded chunks into the final file at the destination.
-    doRequest(backend, Request('MOVE', uploadUrl + '/.file', headers, auth=auth))
+    doRequest(backendUrl, Request('MOVE', uploadUrl + '/.file', headers, auth=auth))
 
-def store(backend, token, fileName, owner):
+def store(backendUrl, token, fileName, owner):
     """
     Triggers the post-processing of a recording previously uploaded in chunks.
 
-    :param backend: the backend to store the recording in.
+    :param backendUrl: the URL of the backend to store the recording in.
     :param token: the token of the conversation that was recorded.
     :param fileName: the name of the file uploaded through the upload share, as
            returned by requestUpload().
     :param owner: the owner of the uploaded file.
     """
 
-    url = backend.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/store'
+    url = backendUrl.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/store'
 
     data = json.dumps({
         'owner': owner,
@@ -345,7 +345,7 @@ def store(backend, token, fileName, owner):
 
     # The checksum is calculated from the conversation token, like in the other
     # recording endpoints.
-    random, checksum = getRandomAndChecksum(backend, token.encode())
+    random, checksum = getRandomAndChecksum(backendUrl, token.encode())
 
     headers = {
         'Content-Type': 'application/json',
@@ -358,9 +358,9 @@ def store(backend, token, fileName, owner):
 
     request = Request('POST', url, headers, data=data)
 
-    doRequest(backend, request)
+    doRequest(backendUrl, request)
 
-def uploadRecordingDirectly(backend, token, fileName, owner):
+def uploadRecordingDirectly(backendUrl, token, fileName, owner):
     """
     Upload the recording specified by fileName directly in a single request.
 
@@ -370,13 +370,13 @@ def uploadRecordingDirectly(backend, token, fileName, owner):
     thus can not upload recordings larger than the limits enforced on a regular
     request.
 
-    :param backend: the backend to upload the file to.
+    :param backendUrl: the URL of the backend to upload the file to.
     :param token: the token of the conversation that was recorded.
     :param fileName: the recording file name.
     :param owner: the owner of the uploaded file.
     """
 
-    url = backend.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/store'
+    url = backendUrl.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/store'
 
     # Plain values become arguments, while tuples become files; the body used to
     # calculate the checksum is empty.
@@ -388,7 +388,7 @@ def uploadRecordingDirectly(backend, token, fileName, owner):
 
     multipartEncoder = MultipartEncoder(data)
 
-    random, checksum = getRandomAndChecksum(backend, token.encode())
+    random, checksum = getRandomAndChecksum(backendUrl, token.encode())
 
     headers = {
         'Content-Type': multipartEncoder.content_type,
@@ -400,4 +400,4 @@ def uploadRecordingDirectly(backend, token, fileName, owner):
 
     uploadRequest = Request('POST', url, headers, data=multipartEncoder)
 
-    doRequest(backend, uploadRequest)
+    doRequest(backendUrl, uploadRequest)

--- a/src/nextcloud/talk/recording/Config.py
+++ b/src/nextcloud/talk/recording/Config.py
@@ -194,6 +194,18 @@ class Config:
         """
         return self._trustedProxies
 
+    def getBackendId(self, backendUrl):
+        """
+        Returns the id of the backend with the given URL.
+
+        If there is no backend with the given URL the URL itself is returned.
+        """
+        backendUrl = backendUrl.rstrip('/')
+        if backendUrl in self._backendIdsByBackendUrl:
+            return self._backendIdsByBackendUrl[backendUrl]
+
+        return backendUrl
+
     def getBackendSecret(self, backendUrl):
         """
         Returns the shared secret for requests from and to the backend servers.

--- a/src/nextcloud/talk/recording/Server.py
+++ b/src/nextcloud/talk/recording/Server.py
@@ -361,8 +361,8 @@ def _startRecordingService(service, actorType, actorId):
     """
     serviceId = f'{service.backendUrl}-{service.token}'
 
-    metricsRecordingsCurrent.labels(service.backendUrl).inc()
-    metricsRecordingsTotal.labels(service.backendUrl).inc()
+    metricsRecordingsCurrent.labels(service.backendId).inc()
+    metricsRecordingsTotal.labels(service.backendId).inc()
 
     try:
         service.start(actorType, actorId)
@@ -379,8 +379,8 @@ def _startRecordingService(service, actorType, actorId):
 
             services.pop(serviceId)
 
-            metricsRecordingsCurrent.labels(service.backendUrl).dec()
-            metricsRecordingsFailedTotal.labels(service.backendUrl).inc()
+            metricsRecordingsCurrent.labels(service.backendId).dec()
+            metricsRecordingsFailedTotal.labels(service.backendId).inc()
 
 def stopRecording(backendUrl, token, data):
     """
@@ -459,7 +459,7 @@ def _stopRecordingService(service, actorType, actorId):
         # the recording (or, rather, to notify the Nextcloud server that the
         # recording was stopped) are implicitly failures to upload the
         # recording, as the upload will not be even tried.
-        metricsRecordingsUploadsFailedTotal.labels(service.backendUrl).inc()
+        metricsRecordingsUploadsFailedTotal.labels(service.backendId).inc()
     finally:
         with servicesLock:
             if serviceId not in servicesStopping:
@@ -468,8 +468,8 @@ def _stopRecordingService(service, actorType, actorId):
             else:
                 servicesStopping.pop(serviceId)
 
-            metricsRecordingsCurrent.labels(service.backendUrl).dec()
-            metricsRecordingsDurationSeconds.labels(service.backendUrl).inc(service.getRecordingDuration())
+            metricsRecordingsCurrent.labels(service.backendId).dec()
+            metricsRecordingsDurationSeconds.labels(service.backendId).inc(service.getRecordingDuration())
 
 # Despite this handler it seems that in some cases the geckodriver could have
 # been killed already when it is executed, which unfortunately prevents a proper

--- a/src/nextcloud/talk/recording/Server.py
+++ b/src/nextcloud/talk/recording/Server.py
@@ -210,16 +210,16 @@ def handleBackendRequest(token):
     """
     Handles backend requests.
     """
-    backend, data = _validateRequest()
+    backendUrl, data = _validateRequest()
 
     if 'type' not in data:
         raise BadRequest()
 
     if data['type'] == 'start':
-        return startRecording(backend, token, data)
+        return startRecording(backendUrl, token, data)
 
     if data['type'] == 'stop':
-        return stopRecording(backend, token, data)
+        return stopRecording(backendUrl, token, data)
 
     raise BadRequest()
 
@@ -227,19 +227,19 @@ def _validateRequest():
     """
     Validates the current request.
 
-    :return: the backend that sent the request and the object representation of
-             the body.
+    :return: the URL of the backend that sent the request and the object
+             representation of the body.
     """
 
     if 'Talk-Recording-Backend' not in request.headers:
         app.logger.warning("Missing Talk-Recording-Backend header")
         raise Forbidden()
 
-    backend = request.headers['Talk-Recording-Backend']
+    backendUrl = request.headers['Talk-Recording-Backend']
 
-    secret = config.getBackendSecret(backend)
+    secret = config.getBackendSecret(backendUrl)
     if not secret:
-        app.logger.warning("No secret configured for backend %s", backend)
+        app.logger.warning("No secret configured for backend %s", backendUrl)
         raise Forbidden()
 
     if 'Talk-Recording-Random' not in request.headers:
@@ -254,7 +254,7 @@ def _validateRequest():
 
     checksum = request.headers['Talk-Recording-Checksum']
 
-    maximumMessageSize = config.getBackendMaximumMessageSize(backend)
+    maximumMessageSize = config.getBackendMaximumMessageSize(backendUrl)
 
     if not request.content_length or request.content_length > maximumMessageSize:
         app.logger.warning("Message size above limit: %d %d", request.content_length, maximumMessageSize)
@@ -267,7 +267,7 @@ def _validateRequest():
         app.logger.warning("Checksum verification failed: %s %s", checksum, expectedChecksum)
         raise Forbidden()
 
-    return backend, json.loads(body)
+    return backendUrl, json.loads(body)
 
 def _calculateChecksum(secret, random, body):
     secret = secret.encode()
@@ -277,7 +277,7 @@ def _calculateChecksum(secret, random, body):
 
     return hmacValue.hexdigest()
 
-def startRecording(backend, token, data):
+def startRecording(backendUrl, token, data):
     """
     Starts the recording in the given backend and room (identified by its
     token).
@@ -303,11 +303,11 @@ def startRecording(backend, token, data):
       }
     }
 
-    :param backend: the backend that send the request.
+    :param backendUrl: the URL of the backend that send the request.
     :param token: the token of the room to start the recording in.
     :param data: the data used to start the recording.
     """
-    serviceId = f'{backend}-{token}'
+    serviceId = f'{backendUrl}-{token}'
 
     if 'start' not in data:
         raise BadRequest()
@@ -336,14 +336,14 @@ def startRecording(backend, token, data):
     service = None
     with servicesLock:
         if serviceId in services:
-            app.logger.warning("Trying to start recording again: %s %s", backend, token)
+            app.logger.warning("Trying to start recording again: %s %s", backendUrl, token)
             return {}
 
-        service = Service(backend, token, status, owner)
+        service = Service(backendUrl, token, status, owner)
 
         services[serviceId] = service
 
-    app.logger.info("Start recording: %s %s", backend, token)
+    app.logger.info("Start recording: %s %s", backendUrl, token)
 
     serviceStartThread = Thread(target=_startRecordingService, args=[service, actorType, actorId], daemon=True)
     serviceStartThread.start()
@@ -359,10 +359,10 @@ def _startRecordingService(service, actorType, actorId):
 
     :param service: the Service to start.
     """
-    serviceId = f'{service.backend}-{service.token}'
+    serviceId = f'{service.backendUrl}-{service.token}'
 
-    metricsRecordingsCurrent.labels(service.backend).inc()
-    metricsRecordingsTotal.labels(service.backend).inc()
+    metricsRecordingsCurrent.labels(service.backendUrl).inc()
+    metricsRecordingsTotal.labels(service.backendUrl).inc()
 
     try:
         service.start(actorType, actorId)
@@ -371,18 +371,18 @@ def _startRecordingService(service, actorType, actorId):
             if serviceId not in services:
                 # Service was already stopped, exception should have been caused
                 # by stopping the helpers even before the recorder started.
-                app.logger.info("Recording stopped before starting: %s %s", service.backend, service.token, exc_info=exception)
+                app.logger.info("Recording stopped before starting: %s %s", service.backendUrl, service.token, exc_info=exception)
 
                 return
 
-            app.logger.exception("Failed to start recording: %s %s", service.backend, service.token)
+            app.logger.exception("Failed to start recording: %s %s", service.backendUrl, service.token)
 
             services.pop(serviceId)
 
-            metricsRecordingsCurrent.labels(service.backend).dec()
-            metricsRecordingsFailedTotal.labels(service.backend).inc()
+            metricsRecordingsCurrent.labels(service.backendUrl).dec()
+            metricsRecordingsFailedTotal.labels(service.backendUrl).inc()
 
-def stopRecording(backend, token, data):
+def stopRecording(backendUrl, token, data):
     """
     Stops the recording in the given backend and room (identified by its token).
 
@@ -401,11 +401,11 @@ def stopRecording(backend, token, data):
       }
     }
 
-    :param backend: the backend that send the request.
+    :param backendUrl: the URL of the backend that send the request.
     :param token: the token of the room to stop the recording in.
     :param data: the data used to stop the recording.
     """
-    serviceId = f'{backend}-{token}'
+    serviceId = f'{backendUrl}-{token}'
 
     if 'stop' not in data:
         raise BadRequest()
@@ -419,11 +419,11 @@ def stopRecording(backend, token, data):
     service = None
     with servicesLock:
         if serviceId not in services and serviceId in servicesStopping:
-            app.logger.info("Trying to stop recording again: %s %s", backend, token)
+            app.logger.info("Trying to stop recording again: %s %s", backendUrl, token)
             return {}
 
         if serviceId not in services:
-            app.logger.warning("Trying to stop unknown recording: %s %s", backend, token)
+            app.logger.warning("Trying to stop unknown recording: %s %s", backendUrl, token)
             raise NotFound()
 
         service = services[serviceId]
@@ -432,7 +432,7 @@ def stopRecording(backend, token, data):
 
         servicesStopping[serviceId] = service
 
-    app.logger.info("Stop recording: %s %s", backend, token)
+    app.logger.info("Stop recording: %s %s", backendUrl, token)
 
     serviceStopThread = Thread(target=_stopRecordingService, args=[service, actorType, actorId], daemon=True)
     serviceStopThread.start()
@@ -448,28 +448,28 @@ def _stopRecordingService(service, actorType, actorId):
 
     :param service: the Service to stop.
     """
-    serviceId = f'{service.backend}-{service.token}'
+    serviceId = f'{service.backendUrl}-{service.token}'
 
     try:
         service.stop(actorType, actorId)
     except Exception:
-        app.logger.exception("Failed to stop recording: %s %s", service.backend, service.token)
+        app.logger.exception("Failed to stop recording: %s %s", service.backendUrl, service.token)
 
         # Besides explicit failures to upload the recording, failures to stop
         # the recording (or, rather, to notify the Nextcloud server that the
         # recording was stopped) are implicitly failures to upload the
         # recording, as the upload will not be even tried.
-        metricsRecordingsUploadsFailedTotal.labels(service.backend).inc()
+        metricsRecordingsUploadsFailedTotal.labels(service.backendUrl).inc()
     finally:
         with servicesLock:
             if serviceId not in servicesStopping:
                 # This should never happen.
-                app.logger.error("Recording stopped when not in the list of stopping services: %s %s", service.backend, service.token)
+                app.logger.error("Recording stopped when not in the list of stopping services: %s %s", service.backendUrl, service.token)
             else:
                 servicesStopping.pop(serviceId)
 
-            metricsRecordingsCurrent.labels(service.backend).dec()
-            metricsRecordingsDurationSeconds.labels(service.backend).inc(service.getRecordingDuration())
+            metricsRecordingsCurrent.labels(service.backendUrl).dec()
+            metricsRecordingsDurationSeconds.labels(service.backendUrl).inc(service.getRecordingDuration())
 
 # Despite this handler it seems that in some cases the geckodriver could have
 # been killed already when it is executed, which unfortunately prevents a proper

--- a/src/nextcloud/talk/recording/Service.py
+++ b/src/nextcloud/talk/recording/Service.py
@@ -123,6 +123,7 @@ class Service:
         self._logger = logging.getLogger(f"{__name__}-{backendUrl}-{token}")
 
         self.backendUrl = backendUrl
+        self.backendId = config.getBackendId(backendUrl)
         self.token = token
         self.status = status
         self.owner = owner

--- a/src/nextcloud/talk/recording/Service.py
+++ b/src/nextcloud/talk/recording/Service.py
@@ -119,10 +119,10 @@ class Service:
     expected to be called from different threads.
     """
 
-    def __init__(self, backend, token, status, owner):
-        self._logger = logging.getLogger(f"{__name__}-{backend}-{token}")
+    def __init__(self, backendUrl, token, status, owner):
+        self._logger = logging.getLogger(f"{__name__}-{backendUrl}-{token}")
 
-        self.backend = backend
+        self.backendUrl = backendUrl
         self.token = token
         self.status = status
         self.owner = owner
@@ -156,14 +156,14 @@ class Service:
                could not be started).
         """
 
-        width = config.getBackendVideoWidth(self.backend)
-        height = config.getBackendVideoHeight(self.backend)
+        width = config.getBackendVideoWidth(self.backendUrl)
+        height = config.getBackendVideoHeight(self.backendUrl)
 
-        directory = config.getBackendDirectory(self.backend).rstrip('/')
+        directory = config.getBackendDirectory(self.backendUrl).rstrip('/')
 
-        sanitizedBackend = ''.join([character for character in self.backend if character.isalnum()])
+        sanitizedBackendUrl = ''.join([character for character in self.backendUrl if character.isalnum()])
 
-        fullDirectory = f'{directory}/{sanitizedBackend}/{self.token}'
+        fullDirectory = f'{directory}/{sanitizedBackendUrl}/{self.token}'
 
         try:
             # Ensure that PulseAudio is running.
@@ -181,7 +181,7 @@ class Service:
                 raise Exception("Display started after recording was stopped")
 
             # Start new audio sink for the audio output of the browser.
-            self._audioModuleIndex, audioSinkIndex, audioSourceIndex = newAudioSink(f"{sanitizedBackend}-{self.token}")
+            self._audioModuleIndex, audioSinkIndex, audioSourceIndex = newAudioSink(f"{sanitizedBackendUrl}-{self.token}")
             audioSinkIndex = str(audioSinkIndex)
             audioSourceIndex = str(audioSourceIndex)
 
@@ -197,7 +197,7 @@ class Service:
             browserPath = config.getBrowserPathForRecording()
 
             self._logger.debug("Starting participant")
-            self._participant = Participant(browser, self.backend, width, height, env, driverPath, browserPath, self._logger)
+            self._participant = Participant(browser, self.backendUrl, width, height, env, driverPath, browserPath, self._logger)
 
             self._logger.debug("Joining call")
             self._participant.joinCall(self.token)
@@ -210,7 +210,7 @@ class Service:
 
             self._started.set()
 
-            BackendNotifier.started(self.backend, self.token, self.status, actorType, actorId)
+            BackendNotifier.started(self.backendUrl, self.token, self.status, actorType, actorId)
 
             extensionlessFileName = f'{fullDirectory}/Recording {datetime.now().strftime("%Y-%m-%d %H-%M-%S")}'
 
@@ -224,7 +224,7 @@ class Service:
             self._process = subprocess.Popen(recorderArguments, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
 
             # Log recorder output.
-            Thread(target=processLog, args=[f"{__name__}.recorder-{self.backend}-{self.token}", self._process.stdout], daemon=True).start()
+            Thread(target=processLog, args=[f"{__name__}.recorder-{self.backendUrl}-{self.token}", self._process.stdout], daemon=True).start()
 
             if self._stopped.is_set():
                 # Not strictly needed, as if the recorder is started after the
@@ -253,7 +253,7 @@ class Service:
                 raise
 
             try:
-                BackendNotifier.failed(self.backend, self.token)
+                BackendNotifier.failed(self.backendUrl, self.token)
             except:
                 pass
 
@@ -277,7 +277,7 @@ class Service:
 
         self._stopHelpers()
 
-        BackendNotifier.stopped(self.backend, self.token, actorType, actorId)
+        BackendNotifier.stopped(self.backendUrl, self.token, actorType, actorId)
 
         if not self._fileName:
             self._logger.error("Recording stopping before starting, nothing to upload")
@@ -289,7 +289,7 @@ class Service:
 
             return
 
-        BackendNotifier.uploadRecording(self.backend, self.token, self._fileName, self.owner)
+        BackendNotifier.uploadRecording(self.backendUrl, self.token, self._fileName, self.owner)
 
         os.remove(self._fileName)
 

--- a/tests/ConfigTest.py
+++ b/tests/ConfigTest.py
@@ -66,6 +66,184 @@ trustedproxies =
 
         assert configLoadedFromString.getTrustedProxies() == []
 
+    def testGetBackendIdWhenNotSet(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+
+    def testGetBackendIdWhenSet(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+backends = first-backend
+
+[first-backend]
+url = https://cloud.server.com
+secret = the-shared-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com') == 'first-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com/') == 'first-backend'
+
+    def testGetBackendIdWhenSetWithTrailingSlashInUrl(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+backends = first-backend
+
+[first-backend]
+url = https://cloud.server.com/
+secret = the-shared-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com') == 'first-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com/') == 'first-backend'
+
+    def testGetBackendIdWhenSetWithSpacesInId(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+backends = backend id with spaces
+
+[backend id with spaces]
+url = https://cloud.server.com/
+secret = the-shared-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com') == 'backend id with spaces'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com/') == 'backend id with spaces'
+
+    def testGetBackendIdWhenSetWithDoubleQuotesInId(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+backends = backend-id-with-"double-quotes"
+
+[backend-id-with-"double-quotes"]
+url = https://cloud.server.com/
+secret = the-shared-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com') == 'backend-id-with-"double-quotes"'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com/') == 'backend-id-with-"double-quotes"'
+
+    def testGetBackendIdWhenSetWithNonLatinCharactersInId(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+backends = backend-id-with-non-latin-characters-कبカ
+
+[backend-id-with-non-latin-characters-कبカ]
+url = https://cloud.server.com/
+secret = the-shared-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com') == 'backend-id-with-non-latin-characters-कبカ'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com/') == 'backend-id-with-non-latin-characters-कبカ'
+
+    def testGetBackendIdWhenAllowingAll(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+allowall = true
+backends = first-backend
+
+[first-backend]
+url = https://cloud.server.com
+secret = the-shared-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com') == 'first-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com/') == 'first-backend'
+
+    def testGetBackendIdWhenExplicitlyDisallowingAll(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+allowall = false
+backends = first-backend
+
+[first-backend]
+url = https://cloud.server.com
+secret = the-shared-secret
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com') == 'first-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server.com/') == 'first-backend'
+
+    def testGetBackendIdWhenSeveralBackends(self, configLoadedFromString):
+        configLoadedFromString.configString = """
+[backend]
+backends = first-backend, second-backend
+
+[first-backend]
+url = https://cloud.server1.com
+secret = the-shared-secret1
+
+[second-backend]
+url = https://cloud.server2.com
+secret = the-shared-secret2
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server1.com') == 'first-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server1.com/') == 'first-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server2.com') == 'second-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server2.com/') == 'second-backend'
+
+    def testGetBackendIdWhenDuplicatedUrl(self, configLoadedFromString, loggerSpy):
+        configLoadedFromString.configString = """
+[backend]
+backends = last-section-but-first-backend, second-backend, third-backend, fourth-backend
+
+[second-backend]
+url = https://cloud.server1.com/
+secret = the-shared-secret1-second
+
+[third-backend]
+url = https://cloud.server1.com
+secret = the-shared-secret1-third
+
+[fourth-backend]
+url = https://cloud.server1.com
+secret = the-shared-secret1-fourth
+
+[last-section-but-first-backend]
+url = https://cloud.server1.com
+secret = the-shared-secret1-last-section-but-first
+"""
+        configLoadedFromString.load('fake-file-name')
+
+        assert loggerSpy.error.call_args_list == [
+            call('Duplicated backend URL (%s), backend "%s" will be ignored', 'https://cloud.server1.com', 'last-section-but-first-backend'),
+            call('Duplicated backend URL (%s), backend "%s" will be ignored', 'https://cloud.server1.com', 'second-backend'),
+            call('Duplicated backend URL (%s), backend "%s" will be ignored', 'https://cloud.server1.com', 'third-backend'),
+        ]
+
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.unknown.com/') == 'https://cloud.unknown.com'
+        assert configLoadedFromString.getBackendId('https://cloud.server1.com') == 'fourth-backend'
+        assert configLoadedFromString.getBackendId('https://cloud.server1.com/') == 'fourth-backend'
+
     def testGetBackendValuesWhenNotSet(self, configLoadedFromString):
         configLoadedFromString.configString = """
 [backend]


### PR DESCRIPTION
[For consistency with the signaling server](https://redirect.github.com/strukturag/nextcloud-spreed-signaling/issues/1013) now the `backend` label in Prometheus metrics uses the backend ID instead of the backend URL.

Nevertheless, there is a slight difference when `allowall` is enabled; in that case the recording server still honours the configuration of defined backends, while the signaling server uses the generic configuration for all of them. Therefore, in the recording server the `backend` label will still be the ID of the backend if one is found, while in the signaling server it will use `compat` for any backend. But that should not matter much, as `allowall` should never be used except for development purposes.

Independently of all that, note that there is no risk of using invalid characters in the labels. In Python INI files [a valid section name can be any string that does not contain `\n`](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure) (unless [ConfigParser.SECTCRE](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.SECTCRE) is used, which it is not in the recording server). Therefore, backend IDs can be any string that does not contain `\n` nor a literal `,`, as [the later is used as separator in the `backends` list](https://github.com/nextcloud/nextcloud-talk-recording/blob/98c49982de35dfa85a442bcd16f304dcb22bb427/src/nextcloud/talk/recording/Config.py#L90). In Prometheus / OpenMetrics [label values may be any valid UTF-8 value](https://github.com/prometheus/OpenMetrics/blob/6c847344ff49fa6241a35e8b4f65bf098da5a161/specification/OpenMetrics.md#metric-1) (which is [a design goal](https://prometheus.io/docs/specs/om/open_metrics_spec_2_0/#metric-and-label-name-characters)), and the library takes care of escaping the string as needed*, so any backend ID should be a valid label value.

*Tested, among others, with python3-prometheus-client 0.7.1 in Ubuntu 20.04, which is the oldest version of all the packaged distributions, and python3-prometheus-client 0.21.1 in Debian 13, which is the newest; double quotes are automatically escaped, so for example `with "` as a backend ID becomes:
```
recording_recordings_duration_seconds_total{backend="with \""} 10.0
```
