### PR TITLE
Fix cropped browser window when using Chromium

### DIFF
--- a/src/nextcloud/talk/recording/Participant.py
+++ b/src/nextcloud/talk/recording/Participant.py
@@ -222,6 +222,7 @@ class SeleniumHelper:
 
         options.add_argument('--kiosk')
         options.add_argument(f'--window-size={width},{height}')
+        options.add_argument('--window-position=0,0')
         options.add_argument('--disable-infobars')
         options.add_experimental_option("excludeSwitches", ["enable-automation"])
 


### PR DESCRIPTION
[Chromium creates new windows in a cascade effect, 10x10 pixels away from the previous one](https://issues.chromium.org/issues/40735776). However, this also applies to the first window if no explicit position is given ([and it seems that it will not be changed](https://issues.chromium.org/issues/40916938)), so even if there is no window manager it appears 10x10 pixels away from the top left corner. Therefore an explicit position of 0,0 needs to be set.

🏚️ Before | 🏡 After
-- | --
<img width="480" height="270" alt="Recording-Chromium-Cropped-Before" src="https://github.com/user-attachments/assets/73da493a-08a7-4d45-bc6a-6a4a4330a859" /> | <img width="480" height="270" alt="Recording-Chromium-Cropped-After" src="https://github.com/user-attachments/assets/24e0b3cb-b97d-4d71-908b-0b8cf4d87f74" />
