### PR TITLE
Fix missing characters in recorded video due to missing fonts

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,6 +89,8 @@ The recording server has the following non-Python dependencies:
 
 Those dependencies must be installed, typically using the package manager of the distribution, in the system running the recording server.
 
+You may also want to install the Noto fonts, again typically using the package manager of the distribution, to ensure that non-latin characters are properly shown in the recordings (for example, in participant names).
+
 Then, the recording server and all its Python dependencies can be installed using Python pip. Note that the recording server is not available in the Python Package Index (PyPI); you need to manually clone the git repository and then install it from there:
 ```
 git clone https://github.com/nextcloud/nextcloud-talk-recording

--- a/packaging/nextcloud-talk-recording/stdeb.cfg
+++ b/packaging/nextcloud-talk-recording/stdeb.cfg
@@ -3,4 +3,4 @@
 [DEFAULT]
 Package3: nextcloud-talk-recording
 Build-Depends: dh-exec
-Depends3: adduser, ffmpeg, firefox, firefox-geckodriver, pulseaudio, xvfb
+Depends3: adduser, ffmpeg, firefox, firefox-geckodriver, fonts-noto, pulseaudio, xvfb


### PR DESCRIPTION
Similar to https://github.com/nextcloud/all-in-one/pull/7706 for (pre-)built packages, and documentation for manual installation

[Nextcloud uses a native font stack](https://redirect.github.com/nextcloud/server/pull/16055) and, if none of the suggested fonts are available, it falls back to the browser defaults. Browsers may
provide its own fonts (for example, Firefox packages may include Twemoji Mozilla), but in general they rely on the system fonts.

When the packages are installed some default system fonts are automatically installed by dependencies (of the "fontconfig-config" package) and therefore used by the browsers. However, those fonts may not provide glyphs for all characters (for example, non-latin characters), so when the browser tries to render them the [the unsupported characters are shown as the .notdef glyph](https://en.wikipedia.org/wiki/Unicode_input#Grapheme_availability) (rectangular boxes).

`fc-list` can be used to check which system font, if any, provides a glyph for certain character. For example, `fc-list :charset=0915` for क, `fc-list :charset=0628` for ب, `fc-list :charset=30AB` for カ, or `fc-list :charset=1F926` for 🤦. Note, however, that `fc-list` only checks the system fonts; an application could provide its own fonts and they would not be found by that command (for example, _/usr/lib/firefox/fonts/TwemojiMozilla.ttf_).

Noto fonts seems to be the most complete font family available in Debian and Ubuntu, and it is not only a default used by browsers when available, but also [one of the suggested native fonts in Nextcloud](https://redirect.github.com/nextcloud/server/pull/39008), so now an explicit dependency to fonts-noto is added to the recording server package.

As the recording server works without the fonts, even if some characters could be missing in the recording, it may not be seen as a mandatory dependency. Nevertheless, it was added as such instead of a `Recommends` to ensure that all the characters will be properly shown.

Moreover, in Ubuntu 24.04 the recording server could be explicitly installed without recommends to avoid pulling the Chromium snap (which is useless here) as a dependency of Selenium, so if the Noto fonts were a `Recommends` that would also require explicitly installing them afterwards. Nevertheless, the Noto fonts require almost 800MB of space to be installed, so it could be also good to allow to optionally not install or uninstall them... but I guess 800MB of space should not be a problem in a machine that will need to (temporarily) store potentially large recordings.

Anyway, the potential issues outweigh the benefit of allowing to optionally not to install or uninstall the fonts, so a mandatory dependency was used.

## How to test

- Build the packages for Debian or Ubuntu and install them
- Log in as an admin in Nextcloud
- Open the Theming settings
- Change the instance name to something with non-latin characters, for example, `कبカ🤦`
- Open Talk
- Start a call
- Start a recording
- Stop the recording
- Check the instance name in the recorded video

### Result with this pull request

The instance name is `कبカ🤦`

### Result without this pull request

The instance name is `☐ب☐🤦` (some characters are still rendered due to the DejaVu and Twemoji Mozilla fonts)
